### PR TITLE
feat: case study layout improvements — container-aware grid, keep exploring

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=@types/*

--- a/apps/web/src/app/(website)/work/[slug]/page.tsx
+++ b/apps/web/src/app/(website)/work/[slug]/page.tsx
@@ -3,7 +3,11 @@ import { notFound } from 'next/navigation'
 
 import { sanityFetch } from '@/sanity/client'
 import { ALL_CASE_STUDY_SLUGS_QUERY } from '@/sanity/queries'
-import { CASE_STUDY_WITH_BLOCKS } from '@/sanity/queries/case-study-queries'
+import {
+  CASE_STUDY_WITH_BLOCKS,
+  PUBLISHED_CASE_STUDIES,
+  caseStudiesTag,
+} from '@/sanity/queries/case-study-queries'
 import type { CaseStudy } from '@/sanity/queries'
 
 import { CaseStudyLayout } from '@/components/case-study-layout'
@@ -35,12 +39,13 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 
 export default async function CaseStudyPage(props: PageProps) {
   const { slug } = await props.params
-  const data = await sanityFetch<CaseStudy | null>(
-    CASE_STUDY_WITH_BLOCKS,
-    { slug },
-    { tag: `caseStudy:${slug}` },
-  )
+  const [data, allStudies] = await Promise.all([
+    sanityFetch<CaseStudy | null>(CASE_STUDY_WITH_BLOCKS, { slug }, { tag: `caseStudy:${slug}` }),
+    sanityFetch<CaseStudy[]>(PUBLISHED_CASE_STUDIES, {}, { tag: caseStudiesTag }),
+  ])
   if (!data) return notFound()
 
-  return <CaseStudyLayout data={data} />
+  const otherStudies = allStudies.filter((study) => study.slug.current !== slug).slice(0, 3)
+
+  return <CaseStudyLayout data={data} otherStudies={otherStudies} />
 }

--- a/apps/web/src/components/case-study-layout.tsx
+++ b/apps/web/src/components/case-study-layout.tsx
@@ -8,15 +8,18 @@ import { PageTemplate } from '@/components/page-template'
 import { CaseStudyBlock } from '@/components/case-study-block'
 import { PortableText } from 'next-sanity'
 import { gridComponents } from '@/components/portable-text-grid'
+import { KeepExploringSection } from '@/components/keep-exploring-section'
+import type { ProjectCardData } from '@/components/project-card'
 import type { CaseStudy } from '@/sanity/queries'
 import { cn } from '@/lib/utils'
 import { createPortal } from 'react-dom'
 
 interface CaseStudyLayoutProps {
   data: CaseStudy
+  otherStudies?: ProjectCardData[]
 }
 
-export function CaseStudyLayout({ data }: CaseStudyLayoutProps) {
+export function CaseStudyLayout({ data, otherStudies }: CaseStudyLayoutProps) {
   const [isPanelOpen, setIsPanelOpen] = React.useState(false)
 
   const togglePanel = () => setIsPanelOpen(!isPanelOpen)
@@ -89,6 +92,7 @@ export function CaseStudyLayout({ data }: CaseStudyLayoutProps) {
           }
         >
           {data.content && <PortableText value={data.content} components={gridComponents} />}
+          {otherStudies && <KeepExploringSection projects={otherStudies} />}
         </PageTemplate>
       </div>
 

--- a/apps/web/src/components/content-grid.tsx
+++ b/apps/web/src/components/content-grid.tsx
@@ -15,7 +15,7 @@ export function ContentGrid({ children, className }: ContentGridProps) {
   return (
     <div
       className={cn(
-        'grid grid-cols-12 gap-y-0 max-w-[var(--content-max-width)] mx-auto w-full',
+        '@container grid grid-cols-12 gap-y-0 max-w-[var(--content-max-width)] mx-auto w-full',
         className,
       )}
     >

--- a/apps/web/src/components/featured-work-section.tsx
+++ b/apps/web/src/components/featured-work-section.tsx
@@ -1,31 +1,16 @@
 'use client'
 
-import * as React from 'react'
 import Link from 'next/link'
 import { gridCols } from '@/lib/grid-columns'
-import { ProjectCard } from '@/components/project-card'
+import { ProjectGrid } from '@/components/project-grid'
 import { Button } from '@/components/ui/button'
-import type { SanityImage } from '@/sanity/queries'
-
-type FeaturedProject = {
-  _id: string
-  title: string
-  slug: { current: string }
-  summary: string
-  coverImage: SanityImage
-  projectInfo?: {
-    sector?: string[]
-    year?: string
-    link?: { text?: string; url?: string }
-  }
-  publishedAt: string
-}
+import type { ProjectCardData } from '@/components/project-card'
 
 type FeaturedWorkSectionProps = {
   label?: string
   heading?: string
   button?: { text?: string; link?: string }
-  projects: FeaturedProject[]
+  projects: ProjectCardData[]
 }
 
 export function FeaturedWorkSection({
@@ -39,7 +24,6 @@ export function FeaturedWorkSection({
   return (
     <section className={`${gridCols.full} pb-16 md:pb-24`}>
       <div className="flex flex-col gap-12 md:gap-16">
-        {/* Header - matching Programs section */}
         <div className="grid grid-cols-12">
           <div className="col-span-12 md:col-span-8 lg:col-span-6 flex flex-col gap-6">
             {label && <p className="text-sm text-muted-foreground mb-0">{label}</p>}
@@ -52,33 +36,7 @@ export function FeaturedWorkSection({
           </div>
         </div>
 
-        {/* Projects Grid/Scroll */}
-        <div className="w-full">
-          {/* Mobile: Horizontal Scroll */}
-          <div className="md:hidden -mx-6">
-            <div className="flex overflow-x-auto snap-x snap-mandatory scrollbar-hide pb-4">
-              <div className="w-6 shrink-0 snap-start" role="presentation" />
-              {projects.map((project, index) => (
-                <div
-                  key={project._id}
-                  className={`flex-none w-[85vw] max-w-sm ${index > 0 ? 'snap-start ml-4' : ''}`}
-                >
-                  <ProjectCard project={project} />
-                </div>
-              ))}
-              <div className="w-6 shrink-0 ml-4" role="presentation" />
-            </div>
-          </div>
-
-          {/* Desktop: Grid */}
-          <div className="hidden md:grid md:grid-cols-12 md:gap-6 lg:gap-8">
-            {projects.map((project) => (
-              <div key={project._id} className="col-span-4">
-                <ProjectCard project={project} />
-              </div>
-            ))}
-          </div>
-        </div>
+        <ProjectGrid projects={projects} />
       </div>
     </section>
   )

--- a/apps/web/src/components/keep-exploring-section.tsx
+++ b/apps/web/src/components/keep-exploring-section.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { gridCols } from '@/lib/grid-columns'
+import { ProjectGrid } from '@/components/project-grid'
+import type { ProjectCardData } from '@/components/project-card'
+
+type KeepExploringSectionProps = {
+  projects: ProjectCardData[]
+}
+
+export function KeepExploringSection({ projects }: KeepExploringSectionProps) {
+  if (!projects || projects.length === 0) return null
+
+  return (
+    <section className={`${gridCols.full} py-16 md:py-24`}>
+      <div className="flex flex-col gap-12 md:gap-16">
+        <div className="flex items-baseline justify-between gap-4">
+          <h2 className="text-4xl font-normal m-0">Keep exploring</h2>
+          <Link
+            href="/work"
+            className="shrink-0 text-base text-foreground underline-offset-4 hover:underline"
+          >
+            View all
+          </Link>
+        </div>
+
+        <ProjectGrid projects={projects} />
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/components/project-card.tsx
+++ b/apps/web/src/components/project-card.tsx
@@ -5,27 +5,32 @@ import Link from 'next/link'
 import { SanityImage } from '@/components/sanity-image'
 import type { SanityImage as SanityImageType } from '@/sanity/queries'
 
-type ProjectCardProps = {
-  project: {
-    title: string
-    slug: { current: string }
-    summary: string
-    coverImage: SanityImageType
-    projectInfo?: {
-      sector?: string[]
-      year?: string
-      link?: { text?: string; url?: string }
-    }
-    publishedAt: string
+export type ProjectCardData = {
+  _id: string
+  title: string
+  slug: { current: string }
+  summary?: string
+  coverImage?: SanityImageType
+  projectInfo?: {
+    sector?: string[]
+    year?: string
+    link?: { text?: string; url?: string }
   }
+  publishedAt?: string
+}
+
+type ProjectCardProps = {
+  project: ProjectCardData
 }
 
 export function ProjectCard({ project }: ProjectCardProps) {
-  const formattedDate = new Date(project.publishedAt).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
+  const formattedDate = project.publishedAt
+    ? new Date(project.publishedAt).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    : undefined
 
   return (
     <article className="group">

--- a/apps/web/src/components/project-grid.tsx
+++ b/apps/web/src/components/project-grid.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { ProjectCard, type ProjectCardData } from '@/components/project-card'
+
+type ProjectGridProps = {
+  projects: ProjectCardData[]
+}
+
+export function ProjectGrid({ projects }: ProjectGridProps) {
+  return (
+    <div className="w-full">
+      <div className="md:hidden -mx-6">
+        <div className="flex overflow-x-auto snap-x snap-mandatory scrollbar-hide pb-4">
+          <div className="w-6 shrink-0 snap-start" role="presentation" />
+          {projects.map((project, index) => (
+            <div
+              key={project._id}
+              className={`flex-none w-[85vw] max-w-sm ${index > 0 ? 'snap-start ml-4' : ''}`}
+            >
+              <ProjectCard project={project} />
+            </div>
+          ))}
+          <div className="w-6 shrink-0 ml-4" role="presentation" />
+        </div>
+      </div>
+
+      <div className="hidden md:grid md:grid-cols-12 md:gap-6 lg:gap-8">
+        {projects.map((project) => (
+          <div key={project._id} className="col-span-4">
+            <ProjectCard project={project} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/grid-columns.ts
+++ b/apps/web/src/lib/grid-columns.ts
@@ -2,7 +2,11 @@
  * Grid column utilities for content layout
  *
  * Pure 12-column grid system matching OpenAI reference pattern.
- * Desktop uses column positioning, mobile uses full width.
+ *
+ * Centered column positioning is driven by the ContentGrid @container width,
+ * not the viewport: it engages only once the content area is desktop-width
+ * (@6xl / 1152px). Narrower containers — tablet, or a column squeezed by the
+ * case study side panel — span full width so text never reads too narrow.
  *
  * Grid container is max 1376px. Column widths:
  * - 6 cols = ~688px (narrow)
@@ -12,13 +16,13 @@
 
 export const gridCols = {
   /** Narrow: 6/12 cols centered (~688px on 1376px container) */
-  narrow: 'col-span-12 md:col-span-6 md:col-start-4',
+  narrow: 'col-span-12 @6xl:col-span-6 @6xl:col-start-4',
 
   /** Medium: 8/12 cols centered (~917px on 1376px container) */
-  medium: 'col-span-12 md:col-span-8 md:col-start-3',
+  medium: 'col-span-12 @6xl:col-span-8 @6xl:col-start-3',
 
   /** Wide: 10/12 cols centered (~1147px on 1376px container) */
-  wide: 'col-span-12 md:col-span-10 md:col-start-2',
+  wide: 'col-span-12 @6xl:col-span-10 @6xl:col-start-2',
 
   /** Full width: all 12 cols */
   full: 'col-span-12',

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,8 +41,8 @@
     "@storybook/react-vite": "^8",
     "@storybook/test": "^8",
     "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
     "storybook": "^8",
     "typescript": "^5",
     "vite": "^5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,10 +116,10 @@ importers:
         version: 2.56.1
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.6.1(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@vercel/speed-insights':
         specifier: ^1.3.1
-        version: 1.3.1(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.3.1(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -137,7 +137,7 @@ importers:
         version: 8.6.0(react@19.2.3)
       geist:
         specifier: ^1.4.2
-        version: 1.4.2(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 1.4.2(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       lucide-react:
         specifier: ^0.541.0
         version: 0.541.0(react@19.2.3)
@@ -146,10 +146,10 @@ importers:
         version: 4.17.2(react@19.2.3)
       next:
         specifier: 15.4.10
-        version: 15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-sanity:
         specifier: ^12.0.5
-        version: 12.0.5(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.13.2)(@sanity/types@4.6.1(@types/react@19.1.10))(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.1.10))(@sanity/types@4.6.1(@types/react@19.1.10)))(@types/node@20.19.10)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(immer@11.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.2)
+        version: 12.0.5(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.13.2)(@sanity/types@4.6.1(@types/react@19.1.10))(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.1.10))(@sanity/types@4.6.1(@types/react@19.1.10)))(@types/node@20.19.10)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(immer@11.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.2)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -195,7 +195,7 @@ importers:
         version: 8.6.14(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))
       '@storybook/nextjs-vite':
         specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.28.0)(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.46.2)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1))
+        version: 9.1.3(@babel/core@7.28.3)(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.46.2)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1))
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.11
@@ -283,7 +283,7 @@ importers:
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
       '@storybook/addon-essentials':
         specifier: ^8
-        version: 8.6.14(@types/react@18.3.23)(storybook@8.6.14(prettier@3.6.2))
+        version: 8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.6.2))
       '@storybook/addon-interactions':
         specifier: ^8
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
@@ -303,14 +303,14 @@ importers:
         specifier: ^20
         version: 20.19.10
       '@types/react':
-        specifier: ^18
-        version: 18.3.23
+        specifier: ^19
+        version: 19.1.10
       '@types/react-dom':
-        specifier: ^18
-        version: 18.3.7(@types/react@18.3.23)
+        specifier: ^19
+        version: 19.1.7(@types/react@19.1.10)
       geist:
         specifier: ^1.4.2
-        version: 1.4.2(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.4.2(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       storybook:
         specifier: ^8
         version: 8.6.14(prettier@3.6.2)
@@ -3526,14 +3526,6 @@ packages:
   '@types/prismjs@1.26.5':
     resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
-  '@types/react-dom@18.3.7':
-    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
-    peerDependencies:
-      '@types/react': ^18.0.0
-
   '@types/react-dom@19.1.7':
     resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
     peerDependencies:
@@ -3546,9 +3538,6 @@ packages:
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
       '@types/react': '*'
-
-  '@types/react@18.3.23':
-    resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
 
   '@types/react@19.1.10':
     resolution: {integrity: sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==}
@@ -10143,12 +10132,6 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mdx-js/react@3.1.0(@types/react@18.3.23)(react@19.2.3)':
-    dependencies:
-      '@types/mdx': 2.0.13
-      '@types/react': 18.3.23
-      react: 19.2.3
-
   '@mdx-js/react@3.1.0(@types/react@19.1.10)(react@19.2.3)':
     dependencies:
       '@types/mdx': 2.0.13
@@ -11556,7 +11539,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 4.6.1(@types/react@19.1.10)(debug@4.4.1)
 
-  '@sanity/visual-editing@5.0.3(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.13.2)(@sanity/types@4.6.1(@types/react@19.1.10))(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.2)':
+  '@sanity/visual-editing@5.0.3(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.13.2)(@sanity/types@4.6.1(@types/react@19.1.10))(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.2)':
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 3.7.4(react@19.2.3)
@@ -11575,7 +11558,7 @@ snapshots:
       xstate: 5.25.0
     optionalDependencies:
       '@sanity/client': 7.13.2
-      next: 15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/types'
@@ -11659,9 +11642,9 @@ snapshots:
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.6.14(@types/react@18.3.23)(storybook@8.6.14(prettier@3.6.2))':
+  '@storybook/addon-docs@8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
-      '@mdx-js/react': 3.1.0(@types/react@18.3.23)(react@19.2.3)
+      '@mdx-js/react': 3.1.0(@types/react@19.1.10)(react@19.2.3)
       '@storybook/blocks': 8.6.14(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@8.6.14(prettier@3.6.2))
       '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@8.6.14(prettier@3.6.2))
@@ -11685,12 +11668,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.6.14(@types/react@18.3.23)(storybook@8.6.14(prettier@3.6.2))':
+  '@storybook/addon-essentials@8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
       '@storybook/addon-actions': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       '@storybook/addon-backgrounds': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       '@storybook/addon-controls': 8.6.14(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-docs': 8.6.14(@types/react@18.3.23)(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/addon-docs': 8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.6.2))
       '@storybook/addon-highlight': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       '@storybook/addon-measure': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       '@storybook/addon-outline': 8.6.14(storybook@8.6.14(prettier@3.6.2))
@@ -11840,18 +11823,18 @@ snapshots:
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/nextjs-vite@9.1.3(@babel/core@7.28.0)(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.46.2)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1))':
+  '@storybook/nextjs-vite@9.1.3(@babel/core@7.28.3)(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.46.2)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1))':
     dependencies:
       '@storybook/builder-vite': 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1))
       '@storybook/react': 9.1.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)
       '@storybook/react-vite': 9.1.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.46.2)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1))
-      next: 15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       storybook: 9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1))
-      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.3)(react@19.2.3)
       vite: 5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)
-      vite-plugin-storybook-nextjs: 2.0.6(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1))
+      vite-plugin-storybook-nextjs: 2.0.6(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1))
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -12217,12 +12200,6 @@ snapshots:
 
   '@types/prismjs@1.26.5': {}
 
-  '@types/prop-types@15.7.15': {}
-
-  '@types/react-dom@18.3.7(@types/react@18.3.23)':
-    dependencies:
-      '@types/react': 18.3.23
-
   '@types/react-dom@19.1.7(@types/react@19.1.10)':
     dependencies:
       '@types/react': 19.1.10
@@ -12234,11 +12211,6 @@ snapshots:
   '@types/react-transition-group@4.4.12(@types/react@19.1.10)':
     dependencies:
       '@types/react': 19.1.10
-
-  '@types/react@18.3.23':
-    dependencies:
-      '@types/prop-types': 15.7.15
-      csstype: 3.1.3
 
   '@types/react@19.1.10':
     dependencies:
@@ -12496,16 +12468,16 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/analytics@1.6.1(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@vercel/edge@1.2.2': {}
 
-  '@vercel/speed-insights@1.3.1(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/speed-insights@1.3.1(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@vercel/stega@1.0.0': {}
@@ -14178,13 +14150,13 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.4.2(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  geist@1.4.2(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
-      next: 15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  geist@1.4.2(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
+  geist@1.4.2(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
-      next: 15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   gensync@1.0.0-beta.2: {}
 
@@ -15291,18 +15263,18 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-sanity@12.0.5(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.13.2)(@sanity/types@4.6.1(@types/react@19.1.10))(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.1.10))(@sanity/types@4.6.1(@types/react@19.1.10)))(@types/node@20.19.10)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(immer@11.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.2):
+  next-sanity@12.0.5(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.13.2)(@sanity/types@4.6.1(@types/react@19.1.10))(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.1.10))(@sanity/types@4.6.1(@types/react@19.1.10)))(@types/node@20.19.10)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(immer@11.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1))(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.2):
     dependencies:
       '@portabletext/react': 6.0.0(react@19.2.3)
       '@sanity/client': 7.13.2
       '@sanity/comlink': 4.0.1
       '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.2)(@sanity/types@4.6.1(@types/react@19.1.10))
       '@sanity/preview-url-secret': 4.0.1(@sanity/client@7.13.2)
-      '@sanity/visual-editing': 5.0.3(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.13.2)(@sanity/types@4.6.1(@types/react@19.1.10))(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.2)
+      '@sanity/visual-editing': 5.0.3(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.13.2)(@sanity/types@4.6.1(@types/react@19.1.10))(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.2)
       dequal: 2.0.3
       groq: 5.0.1
       history: 5.3.0
-      next: 15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       sanity: 4.6.1(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.7(@sanity/schema@4.6.1(@types/react@19.1.10))(@sanity/types@4.6.1(@types/react@19.1.10)))(@types/node@20.19.10)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(immer@11.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1)
@@ -15323,15 +15295,15 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.4.10
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001734
       postcss: 8.4.31
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.2.3)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.4.8
       '@next/swc-darwin-x64': 15.4.8
@@ -15347,15 +15319,15 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.4.10
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001734
       postcss: 8.4.31
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(@babel/core@7.28.3)(react@19.1.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.3)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.4.8
       '@next/swc-darwin-x64': 15.4.8
@@ -16928,17 +16900,17 @@ snapshots:
       stylis: 4.3.2
       tslib: 2.6.2
 
-  styled-jsx@5.1.6(@babel/core@7.28.0)(react@19.2.3):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.3
-    optionalDependencies:
-      '@babel/core': 7.28.0
-
-  styled-jsx@5.1.6(@babel/core@7.28.3)(react@19.1.0):
+  styled-jsx@5.1.6(@babel/core@7.28.0)(react@19.1.0):
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
+    optionalDependencies:
+      '@babel/core': 7.28.0
+
+  styled-jsx@5.1.6(@babel/core@7.28.3)(react@19.2.3):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.3
     optionalDependencies:
       '@babel/core': 7.28.3
 
@@ -17414,13 +17386,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-storybook-nextjs@2.0.6(next@15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)):
+  vite-plugin-storybook-nextjs@2.0.6(next@15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)))(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)):
     dependencies:
       '@next/env': 15.4.6
       image-size: 2.0.2
       magic-string: 0.30.17
       module-alias: 2.2.3
-      next: 15.4.10(@babel/core@7.28.0)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.4.10(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       storybook: 9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1))
       ts-dedent: 2.2.0
       vite: 5.4.19(@types/node@20.19.10)(lightningcss@1.30.1)(terser@5.43.1)


### PR DESCRIPTION
## Summary

- **Container-aware text width**: switched `ContentGrid` to `@container` and raised the `gridCols` threshold to `@6xl` (1152px). Text now spans full width on tablet and when the case study side panel is open — it responds to the actual content area width, not the viewport
- **Keep exploring section**: each case study page now shows up to 3 sibling studies at the bottom, fetched in parallel with the main study, with a "Keep exploring / View all →" header linking to `/work`
- **Shared project grid**: extracted `ProjectGrid` component and `ProjectCardData` type from `featured-work-section` so both the home page and the new section reuse the same responsive grid (mobile snap-scroll + desktop 3-up)

## Test plan

- [ ] Open a case study at ~800px viewport (tablet) — body text should span full width, no narrow centered column
- [ ] Open a case study at desktop, open the "About the project" panel — body text fills the narrowed column instead of a cramped 6/12 slot
- [ ] At full desktop width (≥1152px) — body text renders in the centered narrow reading column as before
- [ ] "Keep exploring" section appears at the bottom of every case study with 3 cards, none matching the current study
- [ ] "View all" link navigates to `/work`
- [ ] Homepage featured work section still renders correctly (reuses `ProjectGrid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)