### PR TITLE
fix: video block rendering — aspect ratio, scroll latch, hairline, cover media

### DIFF
--- a/apps/web/src/app/(website)/[slug]/page.tsx
+++ b/apps/web/src/app/(website)/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { sanityFetch, sanityNoStoreFetch } from '@/sanity/client'
 import { PageTemplate } from '@/components/page-template'
 import { LegalPageContent } from '@/components/legal-page-content'
 import type { PortableTextBlock } from '@portabletext/types'
-import { IMAGE_PROJECTION, type SanityImage } from '@/sanity/queries'
+import { IMAGE_PROJECTION, MUX_VIDEO_PROJECTION, type SanityImage } from '@/sanity/queries'
 import {
   ACTIVE_PORTFOLIO_ACCESS_PROFILE_BY_SLUG,
   type PortfolioAccessProfile,
@@ -12,7 +12,7 @@ import {
 
 type CoverMedia =
   | { type: 'image'; image: SanityImage }
-  | { type: 'video'; video: { asset: { playbackId: string } } }
+  | { type: 'video'; video: { asset: { playbackId: string; aspectRatio?: string } } }
 
 type PageData = {
   _id: string
@@ -88,7 +88,7 @@ export default async function DynamicPage(props: PageProps) {
       coverMedia {
         type,
         image${IMAGE_PROJECTION},
-        video { asset->{ playbackId } }
+        video${MUX_VIDEO_PROJECTION}
       },
       content[]{
         ...,
@@ -98,7 +98,7 @@ export default async function DynamicPage(props: PageProps) {
         },
         _type == 'videoBlock' => {
           ...,
-          video{asset->{playbackId}}
+          video${MUX_VIDEO_PROJECTION}
         },
         _type == 'carouselBlock' => {
           ...,

--- a/apps/web/src/components/case-study-access-gate.tsx
+++ b/apps/web/src/components/case-study-access-gate.tsx
@@ -6,6 +6,7 @@ import { Icon } from '@/components/ui/icon'
 import * as Icons from '@/components/ui/icons'
 import { gridCols } from '@/lib/grid-columns'
 import { useLoginModal } from '@/components/providers/login-modal-provider'
+import { resolveStudyCoverMedia } from '@/lib/cover-media'
 import type { CaseStudy } from '@/sanity/queries'
 
 type CaseStudyAccessGateProps = {
@@ -16,14 +17,7 @@ type CaseStudyAccessGateProps = {
 export function CaseStudyAccessGate({ study, denied = false }: CaseStudyAccessGateProps) {
   const { openLogin } = useLoginModal()
   const href = `/work/${study.slug.current}`
-  const coverMedia =
-    study.headerMedia?.type === 'video' && study.headerMedia?.video?.asset?.playbackId
-      ? { type: 'video' as const, video: study.headerMedia.video }
-      : study.headerMedia?.image
-        ? { type: 'image' as const, image: study.headerMedia.image }
-        : study.coverImage
-          ? { type: 'image' as const, image: study.coverImage }
-          : undefined
+  const coverMedia = resolveStudyCoverMedia(study.headerMedia, study.cover, study.coverImage)
 
   return (
     <PageTemplate

--- a/apps/web/src/components/case-study-layout.tsx
+++ b/apps/web/src/components/case-study-layout.tsx
@@ -11,6 +11,7 @@ import { gridComponents } from '@/components/portable-text-grid'
 import { KeepExploringSection } from '@/components/keep-exploring-section'
 import type { ProjectCardData } from '@/components/project-card'
 import type { CaseStudy } from '@/sanity/queries'
+import { resolveStudyCoverMedia } from '@/lib/cover-media'
 import { cn } from '@/lib/utils'
 import { createPortal } from 'react-dom'
 
@@ -80,15 +81,7 @@ export function CaseStudyLayout({
           }
           subtitle={data.summary}
           className="pb-0"
-          coverMedia={
-            data.headerMedia?.type === 'video' && data.headerMedia?.video?.asset?.playbackId
-              ? { type: 'video', video: data.headerMedia.video }
-              : data.headerMedia?.image
-                ? { type: 'image', image: data.headerMedia.image }
-                : data.coverImage
-                  ? { type: 'image', image: data.coverImage }
-                  : undefined
-          }
+          coverMedia={resolveStudyCoverMedia(data.headerMedia, data.cover, data.coverImage)}
         >
           {data.content && <PortableText value={data.content} components={gridComponents} />}
           {otherStudies && (

--- a/apps/web/src/components/content-block.tsx
+++ b/apps/web/src/components/content-block.tsx
@@ -6,6 +6,7 @@ import { gridCols } from '@/lib/grid-columns'
 import { SanityImage } from '@/components/sanity-image'
 import { MuxContentPlayer } from '@/components/mux-content-player'
 import { DecorativeVideoBlock } from '@/components/decorative-video-block'
+import { DecorativeVideoPlayer } from '@/components/decorative-video-player'
 import { CaseStudyCarousel } from '@/components/case-study-carousel'
 import { PortableText } from 'next-sanity'
 import { typographyComponents } from '@/components/portable-text-grid'
@@ -89,6 +90,7 @@ export function ContentBlock({ block, layout = 'max-width' }: ContentBlockProps)
         <div className={widthClass}>
           <DecorativeVideoBlock
             playbackId={playbackId}
+            aspectRatio={block.video?.asset?.aspectRatio}
             title={block.title}
             description={block.description}
           />
@@ -130,30 +132,36 @@ export function ContentBlock({ block, layout = 'max-width' }: ContentBlockProps)
   }
 
   if (block._type === 'twoColumnImageBlock') {
+    const renderColumn = (kind: string | undefined, image: any, video: any) => {
+      if (kind === 'video') {
+        const playbackId: string | undefined = video?.asset?.playbackId
+        if (!playbackId) return null
+        return (
+          <DecorativeVideoPlayer playbackId={playbackId} aspectRatio={video?.asset?.aspectRatio} />
+        )
+      }
+      if (!image) return null
+      return (
+        <>
+          <SanityImage
+            image={image}
+            className="w-full h-auto rounded-[8px]"
+            sizes="(max-width: 768px) 100vw, 50vw"
+            aspectRatio="auto"
+          />
+          {image?.caption && <div className="text-sm text-muted-foreground">{image.caption}</div>}
+        </>
+      )
+    }
+
     return (
       <section className="w-full">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="space-y-2">
-            <SanityImage
-              image={block.leftImage}
-              className="w-full h-auto rounded-[8px]"
-              sizes="(max-width: 768px) 100vw, 50vw"
-              aspectRatio="auto"
-            />
-            {block.leftImage?.caption && (
-              <div className="text-sm text-muted-foreground">{block.leftImage.caption}</div>
-            )}
+            {renderColumn(block.leftKind, block.leftImage, block.leftVideo)}
           </div>
           <div className="space-y-2">
-            <SanityImage
-              image={block.rightImage}
-              className="w-full h-auto rounded-[8px]"
-              sizes="(max-width: 768px) 100vw, 50vw"
-              aspectRatio="auto"
-            />
-            {block.rightImage?.caption && (
-              <div className="text-sm text-muted-foreground">{block.rightImage.caption}</div>
-            )}
+            {renderColumn(block.rightKind, block.rightImage, block.rightVideo)}
           </div>
         </div>
       </section>

--- a/apps/web/src/components/cover-media-fill.tsx
+++ b/apps/web/src/components/cover-media-fill.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { SanityImage } from '@/components/sanity-image'
+import { DecorativeVideo } from '@/components/decorative-video'
+import { cn } from '@/lib/utils'
+import type { ResolvedCover } from '@/lib/cover-media'
+
+type CoverMediaFillProps = {
+  cover: ResolvedCover
+  sizes: string
+  imageAspectRatio: `${number}/${number}`
+  className?: string
+  priority?: boolean
+}
+
+export function CoverMediaFill({
+  cover,
+  sizes,
+  imageAspectRatio,
+  className,
+  priority,
+}: CoverMediaFillProps) {
+  if (!cover) return null
+
+  if (cover.kind === 'video') {
+    return (
+      <DecorativeVideo
+        playbackId={cover.playbackId}
+        className={cn('pointer-events-none absolute inset-0 h-full w-full', className)}
+        videoClassName="block h-full w-full object-cover"
+      />
+    )
+  }
+
+  return (
+    <SanityImage
+      image={cover.image}
+      className={cn('h-full w-full object-cover', className)}
+      sizes={sizes}
+      aspectRatio={imageAspectRatio}
+      priority={priority}
+    />
+  )
+}

--- a/apps/web/src/components/decorative-video-block.tsx
+++ b/apps/web/src/components/decorative-video-block.tsx
@@ -6,16 +6,18 @@ interface DecorativeVideoBlockProps {
   playbackId: string
   title?: string
   description?: string
+  aspectRatio?: string
 }
 
 export function DecorativeVideoBlock({
   playbackId,
   title,
   description,
+  aspectRatio,
 }: DecorativeVideoBlockProps) {
   return (
     <section className="w-full space-y-3 max-w-[var(--content-max-width)] mx-auto">
-      <DecorativeVideoPlayer playbackId={playbackId} />
+      <DecorativeVideoPlayer playbackId={playbackId} aspectRatio={aspectRatio} />
       {(title || description) && (
         <div className="mx-auto max-w-[592px]">
           {title && <h3 className="text-xl font-semibold">{title}</h3>}

--- a/apps/web/src/components/decorative-video-player.tsx
+++ b/apps/web/src/components/decorative-video-player.tsx
@@ -9,9 +9,21 @@ import { cn } from '@/lib/utils'
 interface DecorativeVideoPlayerProps {
   playbackId: string
   className?: string
+  aspectRatio?: string
 }
 
-export function DecorativeVideoPlayer({ playbackId, className }: DecorativeVideoPlayerProps) {
+function toCssAspectRatio(ratio?: string): string {
+  if (!ratio) return '16 / 9'
+  const [w, h] = ratio.split(/[:/]/).map((n) => Number(n.trim()))
+  if (!w || !h || !Number.isFinite(w) || !Number.isFinite(h)) return '16 / 9'
+  return `${w} / ${h}`
+}
+
+export function DecorativeVideoPlayer({
+  playbackId,
+  className,
+  aspectRatio,
+}: DecorativeVideoPlayerProps) {
   const [isPlaying, setIsPlaying] = React.useState(true)
   const videoRef = React.useRef<HTMLVideoElement>(null)
 
@@ -28,11 +40,16 @@ export function DecorativeVideoPlayer({ playbackId, className }: DecorativeVideo
   }
 
   return (
-    <div className="relative group overflow-hidden rounded-[8px]">
+    <div
+      className={cn('relative group overflow-hidden rounded-[8px]', className)}
+      style={{ aspectRatio: toCssAspectRatio(aspectRatio) }}
+    >
       <DecorativeVideo
         ref={videoRef}
         playbackId={playbackId}
-        className={cn('w-full h-auto', className)}
+        className="absolute inset-0 h-full w-full"
+        // scale-[1.02]: overfills the rounded clip to prevent subpixel hairlines
+        videoClassName="block h-full w-full object-cover scale-[1.02] origin-center"
       />
 
       <div className="absolute bottom-4 right-4 z-10">

--- a/apps/web/src/components/decorative-video.tsx
+++ b/apps/web/src/components/decorative-video.tsx
@@ -22,22 +22,17 @@ export const DecorativeVideo = React.forwardRef<HTMLVideoElement | null, Decorat
     ref,
   ) {
     const containerRef = React.useRef<HTMLDivElement>(null)
-    const playerRef = React.useRef<HTMLVideoElement | null>(null)
-    React.useImperativeHandle<HTMLVideoElement | null, HTMLVideoElement | null>(
-      ref,
-      () => playerRef.current,
-      [],
-    )
 
-    const [isVisible, setIsVisible] = React.useState(false)
+    const [hasBeenVisible, setHasBeenVisible] = React.useState(false)
 
     React.useEffect(() => {
       const container = containerRef.current
       if (!container) return
       const observer = new IntersectionObserver(
         (entries) => {
-          for (const entry of entries) {
-            setIsVisible(entry.isIntersecting)
+          if (entries[0]?.isIntersecting) {
+            setHasBeenVisible(true)
+            observer.disconnect()
           }
         },
         { rootMargin: '200px' },
@@ -48,9 +43,9 @@ export const DecorativeVideo = React.forwardRef<HTMLVideoElement | null, Decorat
 
     return (
       <div ref={containerRef} className={className}>
-        {isVisible ? (
+        {hasBeenVisible ? (
           <MuxContentPlayer
-            ref={playerRef}
+            ref={ref}
             playbackId={playbackId}
             poster={poster}
             autoPlay

--- a/apps/web/src/components/page-template.tsx
+++ b/apps/web/src/components/page-template.tsx
@@ -10,7 +10,7 @@ import type { SanityImage as SanityImageType } from '@/sanity/queries'
 
 type CoverMedia =
   | { type: 'image'; image: SanityImageType }
-  | { type: 'video'; video: { asset: { playbackId: string } } }
+  | { type: 'video'; video: { asset: { playbackId: string; aspectRatio?: string } } }
 
 interface PageTemplateProps {
   /** Page title (uses h2 styling) */
@@ -78,7 +78,7 @@ export function PageTemplate({
             {coverMedia.type === 'video' && coverMedia.video?.asset?.playbackId ? (
               <DecorativeVideoPlayer
                 playbackId={coverMedia.video.asset.playbackId}
-                className="max-h-[90vh] object-cover"
+                aspectRatio={coverMedia.video.asset.aspectRatio}
               />
             ) : coverMedia.type === 'image' && coverMedia.image ? (
               <SanityImage

--- a/apps/web/src/components/project-card.tsx
+++ b/apps/web/src/components/project-card.tsx
@@ -2,8 +2,9 @@
 
 import * as React from 'react'
 import Link from 'next/link'
-import { SanityImage } from '@/components/sanity-image'
-import type { SanityImage as SanityImageType } from '@/sanity/queries'
+import { CoverMediaFill } from '@/components/cover-media-fill'
+import { resolveCover } from '@/lib/cover-media'
+import type { CoverMedia, SanityImage as SanityImageType } from '@/sanity/queries'
 import { Icon } from '@/components/ui/icon'
 import * as Icons from '@/components/ui/icons'
 import { useLoginModal } from '@/components/providers/login-modal-provider'
@@ -14,6 +15,7 @@ export type ProjectCardData = {
   slug: { current: string }
   summary?: string
   visibility?: 'public' | 'recruiter'
+  cover?: CoverMedia
   coverImage?: SanityImageType
   projectInfo?: {
     sector?: string[]
@@ -39,18 +41,17 @@ export function ProjectCard({ project, hasRecruiterAccess = false }: ProjectCard
     : undefined
   const href = `/work/${project.slug.current}`
   const isLocked = project.visibility === 'recruiter' && !hasRecruiterAccess
+  const cover = resolveCover(project.cover, project.coverImage)
 
   const content = (
     <>
       <div className="relative aspect-square mb-3 overflow-hidden rounded-lg bg-muted">
-        {project.coverImage?.asset && (
-          <SanityImage
-            image={project.coverImage}
-            className="h-full w-full object-cover transition-transform duration-300 ease-out group-hover:scale-[1.025]"
-            sizes="(max-width: 768px) 85vw, (max-width: 1200px) 33vw, 450px"
-            aspectRatio="1/1"
-          />
-        )}
+        <CoverMediaFill
+          cover={cover}
+          className="transition-transform duration-300 ease-out group-hover:scale-[1.025]"
+          sizes="(max-width: 768px) 85vw, (max-width: 1200px) 33vw, 450px"
+          imageAspectRatio="1/1"
+        />
       </div>
 
       <div className="space-y-2">

--- a/apps/web/src/components/work-case-study-list.tsx
+++ b/apps/web/src/components/work-case-study-list.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link'
 
 import { SanityImage } from '@/components/sanity-image'
 import { DecorativeVideo } from '@/components/decorative-video'
+import { CoverMediaFill } from '@/components/cover-media-fill'
+import { resolveCover } from '@/lib/cover-media'
 import { Button } from '@/components/ui/button'
 import { Icon } from '@/components/ui/icon'
 import * as Icons from '@/components/ui/icons'
@@ -25,12 +27,11 @@ export function WorkCaseStudyList({
     <div className="flex flex-col gap-8">
       {caseStudies.map((study, index) => {
         const href = `/work/${study.slug.current}`
-        const cover = study.coverImage
+        const cover = resolveCover(study.cover, study.coverImage)
         const header = study.headerMedia
         const heroVideoId = header?.type === 'video' ? header.video?.asset?.playbackId : undefined
         const heroImage = header?.type === 'image' ? header.image : null
-        const desktopImage = heroImage ?? cover
-        const hasMedia = Boolean(heroVideoId || desktopImage)
+        const hasMedia = Boolean(heroVideoId || heroImage || cover)
         const sector = study.projectInfo?.sector?.length
           ? study.projectInfo.sector.join(', ')
           : null
@@ -69,11 +70,11 @@ export function WorkCaseStudyList({
               <div className="order-first flex items-center lg:order-none lg:col-span-3 lg:p-4">
                 {cover ? (
                   <div className="relative aspect-square w-full overflow-hidden rounded-lg bg-muted md:hidden">
-                    <SanityImage
-                      image={cover}
-                      className="h-full w-full object-cover transition-transform duration-300 ease-out group-hover:scale-[1.025]"
+                    <CoverMediaFill
+                      cover={cover}
+                      className="transition-transform duration-300 ease-out group-hover:scale-[1.025]"
                       sizes="(min-width: 768px) 1px, 100vw"
-                      aspectRatio="1/1"
+                      imageAspectRatio="1/1"
                       priority={index === 0}
                     />
                     <div className="pointer-events-none absolute inset-0 rounded-lg ring-1 ring-inset ring-border" />
@@ -86,15 +87,23 @@ export function WorkCaseStudyList({
                       playbackId={heroVideoId}
                       className="pointer-events-none absolute inset-0 transition-transform duration-300 ease-out group-hover:scale-[1.025]"
                     />
-                  ) : desktopImage ? (
+                  ) : heroImage ? (
                     <SanityImage
-                      image={desktopImage}
+                      image={heroImage}
                       className="h-full w-full object-cover transition-transform duration-300 ease-out group-hover:scale-[1.025]"
                       sizes="(min-width: 1024px) 60vw, (min-width: 768px) 100vw, 1px"
                       aspectRatio="16/9"
                       priority={index === 0}
                     />
-                  ) : null}
+                  ) : (
+                    <CoverMediaFill
+                      cover={cover}
+                      className="transition-transform duration-300 ease-out group-hover:scale-[1.025]"
+                      sizes="(min-width: 1024px) 60vw, (min-width: 768px) 100vw, 1px"
+                      imageAspectRatio="16/9"
+                      priority={index === 0}
+                    />
+                  )}
                   <div className="pointer-events-none absolute inset-0 rounded-lg ring-1 ring-inset ring-border" />
                 </div>
               </div>

--- a/apps/web/src/lib/cover-media.ts
+++ b/apps/web/src/lib/cover-media.ts
@@ -1,0 +1,65 @@
+import type { CoverMedia, SanityImage } from '@/sanity/queries'
+
+type HeaderMedia = {
+  type?: 'image' | 'video'
+  image?: SanityImage
+  video?: { asset: { playbackId: string; aspectRatio?: string } }
+}
+
+export function resolveStudyCoverMedia(
+  headerMedia: HeaderMedia | undefined,
+  cover?: CoverMedia,
+  legacyImage?: SanityImage,
+): ReturnType<typeof coverToHeroMedia> {
+  if (headerMedia?.type === 'video' && headerMedia.video?.asset?.playbackId) {
+    return {
+      type: 'video',
+      video: {
+        asset: {
+          playbackId: headerMedia.video.asset.playbackId,
+          aspectRatio: headerMedia.video.asset.aspectRatio,
+        },
+      },
+    }
+  }
+  if (headerMedia?.image) {
+    return { type: 'image', image: headerMedia.image }
+  }
+  return coverToHeroMedia(cover, legacyImage)
+}
+
+export type ResolvedCover =
+  | { kind: 'video'; playbackId: string; aspectRatio?: string }
+  | { kind: 'image'; image: SanityImage }
+  | null
+
+export function resolveCover(cover?: CoverMedia, legacyImage?: SanityImage): ResolvedCover {
+  if (cover?.type === 'video' && cover.video?.asset?.playbackId) {
+    return {
+      kind: 'video',
+      playbackId: cover.video.asset.playbackId,
+      aspectRatio: cover.video.asset.aspectRatio,
+    }
+  }
+  if (cover?.image?.asset) return { kind: 'image', image: cover.image }
+  if (legacyImage?.asset) return { kind: 'image', image: legacyImage }
+  return null
+}
+
+export function coverToHeroMedia(
+  cover?: CoverMedia,
+  legacyImage?: SanityImage,
+):
+  | { type: 'video'; video: { asset: { playbackId: string; aspectRatio?: string } } }
+  | { type: 'image'; image: SanityImage }
+  | undefined {
+  const resolved = resolveCover(cover, legacyImage)
+  if (!resolved) return undefined
+  if (resolved.kind === 'video') {
+    return {
+      type: 'video',
+      video: { asset: { playbackId: resolved.playbackId, aspectRatio: resolved.aspectRatio } },
+    }
+  }
+  return { type: 'image', image: resolved.image }
+}

--- a/apps/web/src/sanity/queries.ts
+++ b/apps/web/src/sanity/queries.ts
@@ -5,6 +5,9 @@ import { groq } from 'next-sanity'
 export const IMAGE_ASSET_PROJECTION = groq`{ _id, url, metadata { lqip, dimensions } }`
 export const IMAGE_PROJECTION = groq`{..., asset->${IMAGE_ASSET_PROJECTION}}`
 
+export const MUX_VIDEO_PROJECTION = groq`{ asset->{ playbackId, "aspectRatio": data.aspect_ratio } }`
+export const COVER_PROJECTION = groq`{ type, image${IMAGE_PROJECTION}, video${MUX_VIDEO_PROJECTION} }`
+
 export const ALL_CASE_STUDY_SLUGS_QUERY = groq`
   *[_type == "caseStudy" && defined(slug.current)]{
     "slug": slug.current
@@ -20,6 +23,7 @@ export const CASE_STUDY_BY_SLUG_QUERY = groq`
     publishedAt,
     seoSettings,
     slug,
+    cover${COVER_PROJECTION},
     coverImage${IMAGE_PROJECTION},
     projectInfo,
 
@@ -31,7 +35,7 @@ export const CASE_STUDY_BY_SLUG_QUERY = groq`
       },
       _type == 'videoBlock' => {
         ...,
-        video{asset->{playbackId}}
+        video${MUX_VIDEO_PROJECTION}
       },
       _type == 'carouselBlock' => {
         ...,
@@ -77,7 +81,7 @@ export type ImageBlock = {
 export type VideoBlock = {
   _type: 'videoBlock'
   _key?: string
-  video: { asset: { playbackId: string } }
+  video: { asset: { playbackId: string; aspectRatio?: string } }
   title?: string
   description?: string
 }
@@ -96,8 +100,18 @@ export type CarouselBlock = {
 export type TwoColumnImageBlock = {
   _type: 'twoColumnImageBlock'
   _key?: string
-  leftImage: SanityImage
-  rightImage: SanityImage
+  leftKind?: 'image' | 'video'
+  rightKind?: 'image' | 'video'
+  leftImage?: SanityImage
+  rightImage?: SanityImage
+  leftVideo?: { asset?: { playbackId?: string; aspectRatio?: string } }
+  rightVideo?: { asset?: { playbackId?: string; aspectRatio?: string } }
+}
+
+export type CoverMedia = {
+  type?: 'image' | 'video'
+  image?: SanityImage
+  video?: { asset?: { playbackId?: string; aspectRatio?: string } }
 }
 
 export type CaseStudy = {
@@ -108,11 +122,13 @@ export type CaseStudy = {
   visibility?: 'public' | 'recruiter'
   slug: { current: string }
   publishedAt?: string
+  cover?: CoverMedia
+  /** @deprecated Legacy field; migrated into `cover`. Kept for fallback until the migration runs. */
   coverImage?: SanityImage
   headerMedia?: {
     type: 'image' | 'video'
     image?: SanityImage
-    video?: { asset: { playbackId: string } }
+    video?: { asset: { playbackId: string; aspectRatio?: string } }
   }
   projectInfo?: {
     client?: string

--- a/apps/web/src/sanity/queries/case-study-queries.ts
+++ b/apps/web/src/sanity/queries/case-study-queries.ts
@@ -1,5 +1,5 @@
 import { groq } from 'next-sanity'
-import { IMAGE_PROJECTION } from '../queries'
+import { COVER_PROJECTION, IMAGE_PROJECTION, MUX_VIDEO_PROJECTION } from '../queries'
 
 export const caseStudyTag = (slug: string) => `caseStudy:${slug}`
 export const caseStudiesTag = 'caseStudies'
@@ -13,20 +13,22 @@ const CASE_STUDY_BLOCKS_PROJECTION = groq`{
   _type == 'videoBlock' => {
     ...,
     mode,
-    video{asset->{playbackId}}
+    video${MUX_VIDEO_PROJECTION}
   },
   _type == 'carouselBlock' => {
     ...,
     items[]{
       kind,
       image${IMAGE_PROJECTION},
-      video{asset->{playbackId}}
+      video${MUX_VIDEO_PROJECTION}
     }
   },
   _type == 'twoColumnImageBlock' => {
     ...,
     leftImage${IMAGE_PROJECTION},
-    rightImage${IMAGE_PROJECTION}
+    rightImage${IMAGE_PROJECTION},
+    leftVideo${MUX_VIDEO_PROJECTION},
+    rightVideo${MUX_VIDEO_PROJECTION}
   }
 }`
 
@@ -40,11 +42,12 @@ export const CASE_STUDY_WITH_BLOCKS = groq`
     publishedAt,
     seoSettings,
     slug,
+    cover${COVER_PROJECTION},
     coverImage${IMAGE_PROJECTION},
     headerMedia{
       type,
       image${IMAGE_PROJECTION},
-      video{asset->{playbackId}}
+      video${MUX_VIDEO_PROJECTION}
     },
     projectInfo,
 
@@ -62,11 +65,12 @@ export const CASE_STUDY_TEASER_BY_SLUG = groq`
     "visibility": coalesce(visibility, "public"),
     publishedAt,
     slug,
+    cover${COVER_PROJECTION},
     coverImage${IMAGE_PROJECTION},
     headerMedia{
       type,
       image${IMAGE_PROJECTION},
-      video{asset->{playbackId}}
+      video${MUX_VIDEO_PROJECTION}
     },
     projectInfo{
       sector,
@@ -84,11 +88,12 @@ export const PUBLISHED_CASE_STUDIES = groq`
     slug,
     featuredOrder,
     publishedAt,
+    cover${COVER_PROJECTION},
     coverImage${IMAGE_PROJECTION},
     headerMedia{
       type,
       image${IMAGE_PROJECTION},
-      video{asset->{playbackId}}
+      video${MUX_VIDEO_PROJECTION}
     },
     projectInfo
   }

--- a/apps/web/src/sanity/queries/home-page-queries.ts
+++ b/apps/web/src/sanity/queries/home-page-queries.ts
@@ -1,5 +1,11 @@
 import { groq } from 'next-sanity'
-import { IMAGE_PROJECTION, type SanityImage } from '../queries'
+import {
+  COVER_PROJECTION,
+  IMAGE_PROJECTION,
+  MUX_VIDEO_PROJECTION,
+  type CoverMedia,
+  type SanityImage,
+} from '../queries'
 
 export const homePageTag = 'homePage'
 
@@ -15,7 +21,7 @@ export const HOME_PAGE_QUERY = groq`
     coverMedia{
       type,
       image${IMAGE_PROJECTION},
-      video{asset->{playbackId}}
+      video${MUX_VIDEO_PROJECTION}
     },
     programsSection{
       label,
@@ -37,6 +43,7 @@ export const HOME_PAGE_QUERY = groq`
         slug,
         summary,
         "visibility": coalesce(visibility, "public"),
+        cover${COVER_PROJECTION},
         coverImage${IMAGE_PROJECTION},
         projectInfo{
           sector,
@@ -60,7 +67,7 @@ export type HomePage = {
   coverMedia?: {
     type: 'image' | 'video'
     image?: SanityImage
-    video?: { asset: { playbackId: string } }
+    video?: { asset: { playbackId: string; aspectRatio?: string } }
   }
   programsSection?: {
     label?: string
@@ -82,7 +89,8 @@ export type HomePage = {
       slug: { current: string }
       summary: string
       visibility?: 'public' | 'recruiter'
-      coverImage: SanityImage
+      cover?: CoverMedia
+      coverImage?: SanityImage
       projectInfo?: {
         sector?: string[]
         year?: string

--- a/apps/web/src/sanity/schemas/case-study.ts
+++ b/apps/web/src/sanity/schemas/case-study.ts
@@ -63,21 +63,61 @@ export const caseStudy = defineType({
     }),
 
     defineField({
-      name: 'coverImage',
-      title: 'Cover Image',
-      type: 'image',
-      options: {
-        hotspot: true,
-      },
+      name: 'cover',
+      title: 'Cover',
+      description:
+        'Cover media shown on cards and as the hero fallback. Choose Image or Video, then upload the asset.',
+      type: 'object',
+      options: { collapsed: false, collapsible: false },
       fields: [
-        {
-          name: 'alt',
+        defineField({
+          name: 'type',
+          title: 'Media Type',
           type: 'string',
-          title: 'Alt text',
+          options: {
+            list: [
+              { title: 'Image', value: 'image' },
+              { title: 'Video', value: 'video' },
+            ],
+            layout: 'radio',
+          },
+          initialValue: 'image',
           validation: (Rule) => Rule.required(),
-        },
+        }),
+        defineField({
+          name: 'image',
+          title: 'Image',
+          type: 'image',
+          options: { hotspot: true },
+          hidden: ({ parent }) => parent?.type !== 'image',
+          fields: [
+            {
+              name: 'alt',
+              type: 'string',
+              title: 'Alt text',
+              validation: (Rule) => Rule.required(),
+            },
+          ],
+          validation: (Rule) =>
+            Rule.custom((value, context) => {
+              const parent = context.parent as { type?: string } | undefined
+              if (parent?.type === 'image' && !value) return 'An image is required'
+              return true
+            }),
+        }),
+        defineField({
+          name: 'video',
+          title: 'Video',
+          type: 'mux.video',
+          hidden: ({ parent }) => parent?.type !== 'video',
+          validation: (Rule) =>
+            Rule.custom((value, context) => {
+              const parent = context.parent as { type?: string } | undefined
+              if (parent?.type === 'video' && !value) return 'A video is required'
+              return true
+            }),
+        }),
       ],
-      validation: (Rule) => Rule.required(),
     }),
 
     defineField({
@@ -223,7 +263,7 @@ export const caseStudy = defineType({
   preview: {
     select: {
       title: 'title',
-      media: 'coverImage',
+      media: 'cover.image',
     },
     prepare({ title, media }) {
       return {

--- a/apps/web/src/sanity/schemas/objects/two-column-image-block.ts
+++ b/apps/web/src/sanity/schemas/objects/two-column-image-block.ts
@@ -6,10 +6,24 @@ export const twoColumnImageBlock = defineType({
   type: 'object',
   fields: [
     defineField({
+      name: 'leftKind',
+      title: 'Left Column Type',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Image', value: 'image' },
+          { title: 'Video (Mux)', value: 'video' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'image',
+    }),
+    defineField({
       name: 'leftImage',
       title: 'Left Image',
       type: 'image',
       options: { hotspot: true },
+      hidden: ({ parent }) => parent?.leftKind === 'video',
       fields: [
         {
           name: 'alt',
@@ -25,10 +39,30 @@ export const twoColumnImageBlock = defineType({
       ],
     }),
     defineField({
+      name: 'leftVideo',
+      title: 'Left Video',
+      type: 'mux.video',
+      hidden: ({ parent }) => parent?.leftKind !== 'video',
+    }),
+    defineField({
+      name: 'rightKind',
+      title: 'Right Column Type',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Image', value: 'image' },
+          { title: 'Video (Mux)', value: 'video' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'image',
+    }),
+    defineField({
       name: 'rightImage',
       title: 'Right Image',
       type: 'image',
       options: { hotspot: true },
+      hidden: ({ parent }) => parent?.rightKind === 'video',
       fields: [
         {
           name: 'alt',
@@ -43,14 +77,24 @@ export const twoColumnImageBlock = defineType({
         },
       ],
     }),
+    defineField({
+      name: 'rightVideo',
+      title: 'Right Video',
+      type: 'mux.video',
+      hidden: ({ parent }) => parent?.rightKind !== 'video',
+    }),
   ],
   preview: {
     select: {
       media: 'leftImage',
+      leftKind: 'leftKind',
+      rightKind: 'rightKind',
     },
-    prepare({ media }) {
+    prepare({ media, leftKind, rightKind }) {
+      const describe = (kind?: string) => (kind === 'video' ? 'Video' : 'Image')
       return {
-        title: 'Two Column Images',
+        title: 'Two Column',
+        subtitle: `${describe(leftKind)} + ${describe(rightKind)}`,
         media,
       }
     },

--- a/migrations/cover-media-object/index.ts
+++ b/migrations/cover-media-object/index.ts
@@ -1,0 +1,30 @@
+import { defineMigration, at, set, unset } from 'sanity/migrate'
+
+/**
+ * Move the legacy `coverImage` (a plain image) into the new `cover` media
+ * object: `{ type: 'image', image: <coverImage> }`.
+ *
+ * Reason: the case-study cover is being unified with the Header Media pattern so
+ * editors can choose Image or Video. Existing documents only have `coverImage`,
+ * so this backfills `cover` and removes the orphaned field.
+ *
+ * Run with:
+ *   pnpm dlx sanity migration run cover-media-object --no-dry-run
+ *   (defaults to the dataset in sanity.cli.ts; pass --dataset to override)
+ */
+export default defineMigration({
+  title: "Move coverImage into cover { type: 'image', image }",
+  documentTypes: ['caseStudy'],
+
+  migrate: {
+    document(doc) {
+      const legacy = (doc as { coverImage?: unknown; cover?: unknown }).coverImage
+      const existingCover = (doc as { cover?: unknown }).cover
+
+      // Only migrate documents that still have the legacy field and no cover yet.
+      if (!legacy || existingCover) return []
+
+      return [at('cover', set({ type: 'image', image: legacy })), at('coverImage', unset())]
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- **Scroll latch**: decorative video was unmounting on scroll because `isVisible` toggled both ways. Replaced with a one-way `hasBeenVisible` latch; observer disconnects after first intersection.
- **Hairline border**: `scale-[1.02]` overfill covers subpixel gaps at `overflow-hidden` + `rounded-[8px]` clip edges.
- **Play/pause button**: was doing nothing because `useImperativeHandle` captured `null` at mount (before dynamic import attached). Removed the shim; `ref` is now forwarded directly to `MuxContentPlayer`.
- **Frame sizing**: outer frame div drives layout via `style={{ aspectRatio }}` from actual Mux `data.aspect_ratio` (parsed from `"W:H"` string). Inner video uses `absolute inset-0` fill — no more percentage-height resolution issues inside CSS grid that caused the case-study expand bug.
- **Two-column block**: added `leftKind`/`rightKind` radio + `leftVideo`/`rightVideo` mux fields to Sanity schema; `content-block.tsx` renders `DecorativeVideoPlayer` per column when kind is video.
- **Cover media**: redesigned case study `coverImage` field to a `cover` object (image/video selector, mirrors headerMedia). Legacy `coverImage` kept as fallback via `resolveCover()` until migration runs.
- **GROQ fragments**: `MUX_VIDEO_PROJECTION` and `COVER_PROJECTION` used consistently across all queries.
- **Dedup**: extracted `resolveStudyCoverMedia()` to `cover-media.ts` — eliminates verbatim `headerMedia → coverMedia` ternaries that were copy-pasted into `CaseStudyLayout` and `CaseStudyAccessGate`.

## Migration

A Sanity content migration ships with this PR to move `coverImage` → `cover.image` on existing case study documents. It must be run manually after merge:

```
pnpm dlx sanity migration run cover-media-object --no-dry-run
```

All queries project both `cover` and `coverImage` until then; `resolveCover()` prefers `cover` with fallback to `coverImage`.

## Test plan

- [ ] Scroll a page with decorative video blocks — videos should stay mounted after first intersection, not disappear/reappear
- [ ] Check decorative video frame for hairline border at rounded corners
- [ ] Click play/pause button on a decorative video — should toggle correctly
- [ ] Load a case study page at full width and resize — video frame should not change size with viewport height
- [ ] Check video aspect ratio on non-16:9 videos (frame should match actual ratio)
- [ ] Add a two-column block in Sanity, set one column to Video — should render the video
- [ ] Create/edit a case study with a video cover — should show on work list card (mobile square tile) and as hero fallback
- [ ] Run the Sanity migration on staging: `pnpm dlx sanity migration run cover-media-object --no-dry-run`

## Security notes

No new API surface, no new env vars.

## Env changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)