### PR TITLE
refactor: extract shared FullBleedCarousel component

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -218,6 +218,51 @@
   animation: slideUp 1s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+@layer components {
+  /**
+   * Full-bleed horizontal carousel: escapes the centered content container to
+   * both browser edges while its slides rest aligned to the content column.
+   *
+   * Reason: the inset is expressed explicitly (via `--content-max-width`) rather
+   * than with `%`, because `padding` percentages resolve against the containing
+   * block (content width) while `scroll-padding` percentages resolve against the
+   * scrollport (100vw). A `%`-based value therefore makes the two disagree, and
+   * with `snap-mandatory` the browser auto-scrolls the first slide off the
+   * content edge on load. Driving margin/padding/scroll-padding from one
+   * viewport-based length keeps them identical, so `scrollLeft` stays 0.
+   */
+  .carousel-bleed {
+    /* Distance from the viewport edge to the content-column edge. */
+    --carousel-edge: max(1.5rem, calc((100vw - var(--content-max-width)) / 2));
+    /* Where slides rest (defaults to the content edge; widened for `medium`). */
+    --carousel-inset: var(--carousel-edge);
+    box-sizing: border-box;
+    width: 100vw;
+    margin-left: calc(-1 * var(--carousel-edge));
+    padding-left: var(--carousel-inset);
+    padding-right: var(--carousel-inset);
+    scroll-padding-left: var(--carousel-inset);
+  }
+
+  @media (min-width: 768px) {
+    .carousel-bleed {
+      --carousel-edge: max(2rem, calc((100vw - var(--content-max-width)) / 2));
+    }
+  }
+
+  /**
+   * Rest slides at the medium (8/12 centered) column once the content area
+   * reaches desktop width, matching `gridCols.medium` (2/12 = 1/6 inset).
+   */
+  @container (min-width: 72rem) {
+    .carousel-bleed-medium {
+      --carousel-inset: calc(
+        var(--carousel-edge) + min(var(--content-max-width), 100vw - 4rem) / 6
+      );
+    }
+  }
+}
+
 /* ============================================
    Media Chrome Video Player Theme
    ============================================ */

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -218,26 +218,6 @@
   animation: slideUp 1s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-@layer components {
-  .viewport-carousel {
-    box-sizing: border-box;
-    margin-left: calc(50% - 50vw);
-    width: 100vw;
-    padding-left: max(1.5rem, calc(50vw - 50%));
-    scroll-padding-left: max(1.5rem, calc(50vw - 50%));
-  }
-
-  .viewport-carousel-track {
-    padding-right: 1.5rem;
-  }
-
-  @media (min-width: 768px) {
-    .viewport-carousel-track {
-      padding-right: 2rem;
-    }
-  }
-}
-
 /* ============================================
    Media Chrome Video Player Theme
    ============================================ */

--- a/apps/web/src/components/full-bleed-carousel.tsx
+++ b/apps/web/src/components/full-bleed-carousel.tsx
@@ -1,0 +1,58 @@
+import { cn } from '@/lib/utils'
+import type { ReactNode } from 'react'
+
+type CarouselAlign = 'full' | 'medium'
+
+type FullBleedCarouselProps = {
+  /**
+   * Slides to render. Each child controls its own width and should include
+   * `flex-none snap-start` (e.g. `w-[85vw] max-w-sm flex-none snap-start`).
+   */
+  children: ReactNode
+  /**
+   * Where the carousel's resting edges sit at scroll start and end.
+   * - `full` (default): aligned to the content-column edge.
+   * - `medium`: inset to match `gridCols.medium` (8/12 centered) once the
+   *   content area reaches desktop width (`@6xl`).
+   */
+  align?: CarouselAlign
+  /** Gap utility classes between slides. */
+  gapClassName?: string
+  className?: string
+}
+
+/**
+ * Horizontal snap carousel that bleeds to both browser edges while its slides
+ * rest aligned to the surrounding content column.
+ *
+ * Reason: `ml-[calc(50%-50vw)] w-screen` escapes the centered content container,
+ * and the symmetric `max(1.5rem, calc(50vw - 50%))` padding restores the resting
+ * position to the content edge — which equals `main`'s `px-6`/`px-8` at each
+ * breakpoint. `scroll-padding-left` mirrors `padding-left` so `snap-start`
+ * slides land on the content edge rather than the raw viewport edge.
+ */
+export function FullBleedCarousel({
+  children,
+  align = 'full',
+  gapClassName = 'gap-4 md:gap-6 lg:gap-8',
+  className,
+}: FullBleedCarouselProps) {
+  return (
+    <div
+      className={cn(
+        'flex snap-x snap-mandatory overflow-x-auto pb-4 scrollbar-hide',
+        'ml-[calc(50%_-_50vw)] w-screen',
+        'pl-[max(1.5rem,calc(50vw_-_50%))] pr-[max(1.5rem,calc(50vw_-_50%))]',
+        '[scroll-padding-left:max(1.5rem,calc(50vw_-_50%))]',
+        align === 'medium' && [
+          '@6xl:pl-[calc(max(1.5rem,50vw_-_50%)_+_16.6667%)] @6xl:pr-[calc(max(1.5rem,50vw_-_50%)_+_16.6667%)]',
+          '@6xl:[scroll-padding-left:calc(max(1.5rem,50vw_-_50%)_+_16.6667%)]',
+        ],
+        gapClassName,
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/web/src/components/full-bleed-carousel.tsx
+++ b/apps/web/src/components/full-bleed-carousel.tsx
@@ -13,7 +13,7 @@ type FullBleedCarouselProps = {
    * Where the carousel's resting edges sit at scroll start and end.
    * - `full` (default): aligned to the content-column edge.
    * - `medium`: inset to match `gridCols.medium` (8/12 centered) once the
-   *   content area reaches desktop width (`@6xl`).
+   *   content area reaches desktop width (`@6xl` / 72rem).
    */
   align?: CarouselAlign
   /** Gap utility classes between slides. */
@@ -25,11 +25,8 @@ type FullBleedCarouselProps = {
  * Horizontal snap carousel that bleeds to both browser edges while its slides
  * rest aligned to the surrounding content column.
  *
- * Reason: `ml-[calc(50%-50vw)] w-screen` escapes the centered content container,
- * and the symmetric `max(1.5rem, calc(50vw - 50%))` padding restores the resting
- * position to the content edge — which equals `main`'s `px-6`/`px-8` at each
- * breakpoint. `scroll-padding-left` mirrors `padding-left` so `snap-start`
- * slides land on the content edge rather than the raw viewport edge.
+ * The bleed + content-aligned padding live in the `.carousel-bleed` class (see
+ * globals.css); see there for why the inset is viewport-based rather than `%`.
  */
 export function FullBleedCarousel({
   children,
@@ -41,13 +38,8 @@ export function FullBleedCarousel({
     <div
       className={cn(
         'flex snap-x snap-mandatory overflow-x-auto pb-4 scrollbar-hide',
-        'ml-[calc(50%_-_50vw)] w-screen',
-        'pl-[max(1.5rem,calc(50vw_-_50%))] pr-[max(1.5rem,calc(50vw_-_50%))]',
-        '[scroll-padding-left:max(1.5rem,calc(50vw_-_50%))]',
-        align === 'medium' && [
-          '@6xl:pl-[calc(max(1.5rem,50vw_-_50%)_+_16.6667%)] @6xl:pr-[calc(max(1.5rem,50vw_-_50%)_+_16.6667%)]',
-          '@6xl:[scroll-padding-left:calc(max(1.5rem,50vw_-_50%)_+_16.6667%)]',
-        ],
+        'carousel-bleed',
+        align === 'medium' && 'carousel-bleed-medium',
         gapClassName,
         className,
       )}

--- a/apps/web/src/components/program-layout.tsx
+++ b/apps/web/src/components/program-layout.tsx
@@ -5,6 +5,7 @@ import { ProgramHeroExamples } from '@/components/program-hero-examples'
 import { SanityImage } from '@/components/sanity-image'
 import { DecorativeVideo } from '@/components/decorative-video'
 import { Button } from '@/components/ui/button'
+import { FullBleedCarousel } from '@/components/full-bleed-carousel'
 import { gridCols } from '@/lib/grid-columns'
 import { cn } from '@/lib/utils'
 import type { Program, ProgramMove, ProgramProof } from '@/sanity/queries/program-queries'
@@ -174,16 +175,7 @@ function ProofSection({ intro, proofs }: { intro?: string; proofs?: ProgramProof
         )}
       </section>
       <section className={cn(gridCols.full, 'pb-12 md:pb-16')}>
-        <div
-          className={cn(
-            'flex snap-x snap-mandatory gap-2 overflow-x-auto pb-4 scrollbar-hide',
-            'ml-[calc(50%_-_50vw)] w-screen',
-            'pl-[max(1.5rem,calc(50vw_-_50%))] pr-[max(1.5rem,calc(50vw_-_50%))]',
-            '[scroll-padding-left:max(1.5rem,calc(50vw_-_50%))]',
-            '@6xl:pl-[calc(max(1.5rem,50vw_-_50%)_+_16.6667%)] @6xl:pr-[calc(max(1.5rem,50vw_-_50%)_+_16.6667%)]',
-            '@6xl:[scroll-padding-left:calc(max(1.5rem,50vw_-_50%)_+_16.6667%)]',
-          )}
-        >
+        <FullBleedCarousel align="medium" gapClassName="gap-2">
           {validProofs.map((proof) => (
             <div
               key={proof._key}
@@ -192,7 +184,7 @@ function ProofSection({ intro, proofs }: { intro?: string; proofs?: ProgramProof
               <ProofCard proof={proof} />
             </div>
           ))}
-        </div>
+        </FullBleedCarousel>
       </section>
     </>
   )

--- a/apps/web/src/components/project-grid.tsx
+++ b/apps/web/src/components/project-grid.tsx
@@ -1,5 +1,4 @@
-'use client'
-
+import { FullBleedCarousel } from '@/components/full-bleed-carousel'
 import { ProjectCard, type ProjectCardData } from '@/components/project-card'
 
 type ProjectGridProps = {
@@ -9,17 +8,15 @@ type ProjectGridProps = {
 
 export function ProjectGrid({ projects, hasRecruiterAccess = false }: ProjectGridProps) {
   return (
-    <div className="w-full">
-      <div className="viewport-carousel viewport-carousel-track flex snap-x snap-mandatory gap-4 overflow-x-auto pb-4 scrollbar-hide md:gap-6 lg:gap-8">
-        {projects.map((project) => (
-          <div
-            key={project._id}
-            className="w-[85vw] max-w-sm flex-none snap-start md:w-[30vw] md:min-w-80 md:max-w-md"
-          >
-            <ProjectCard project={project} hasRecruiterAccess={hasRecruiterAccess} />
-          </div>
-        ))}
-      </div>
-    </div>
+    <FullBleedCarousel>
+      {projects.map((project) => (
+        <div
+          key={project._id}
+          className="w-[85vw] max-w-sm flex-none snap-start md:w-[30vw] md:min-w-80 md:max-w-md"
+        >
+          <ProjectCard project={project} hasRecruiterAccess={hasRecruiterAccess} />
+        </div>
+      ))}
+    </FullBleedCarousel>
   )
 }


### PR DESCRIPTION
## Summary

- New `FullBleedCarousel` component consolidates the full-bleed horizontal scroll logic (viewport escape, content-aligned resting edges, snap padding) used across the home and strengths pages
- `align` prop: `'full'` (content column edge — home carousels) or `'medium'` (8/12 centered column — strengths proof cards)
- `gapClassName` prop for per-use gap control
- `ProjectGrid` (featured-work + keep-exploring on home/work pages) now uses it — fixes the carousel **end overshooting** past the content column on wide viewports (the old `.viewport-carousel-track` used flat right padding instead of the symmetric content-aligned formula)
- `ProgramLayout` proof carousel uses it with `align="medium"`
- Removes the now-unused `.viewport-carousel` CSS classes from `globals.css`

## Test plan

- [ ] Home page: featured work + keep-exploring carousels start **and finish** aligned to the content column edge on wide viewports
- [ ] `/strengths/[slug]`: proof cards start/end aligned to the medium (8/12) column
- [ ] Full-bleed scroll in both directions to browser edges on all carousel instances
- [ ] Snap behaviour: cards snap to the correct content/column left edge
- [ ] Check at mobile, md, and wide (>1152px) viewport widths

## Security notes

None.

## Env changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)