### PR TITLE
feat: show other strengths on strength detail pages

### DIFF
--- a/apps/web/src/app/(website)/strengths/[slug]/page.tsx
+++ b/apps/web/src/app/(website)/strengths/[slug]/page.tsx
@@ -4,6 +4,11 @@ import { notFound } from 'next/navigation'
 import { sanityFetch } from '@/sanity/client'
 import { PROGRAM_BY_SLUG, programTag } from '@/sanity/queries/program-queries'
 import type { Program } from '@/sanity/queries/program-queries'
+import {
+  HOME_PAGE_PROGRAMS_QUERY,
+  homePageTag,
+  type HomePageProgram,
+} from '@/sanity/queries/home-page-queries'
 import { ProgramLayout } from '@/components/program-layout'
 
 export const dynamic = 'force-dynamic'
@@ -29,13 +34,14 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 export default async function StrengthPage(props: PageProps) {
   const { slug } = await props.params
 
-  const data = await sanityFetch<Program | null>(
-    PROGRAM_BY_SLUG,
-    { slug },
-    { tag: programTag(slug) },
-  )
+  const [data, homePrograms] = await Promise.all([
+    sanityFetch<Program | null>(PROGRAM_BY_SLUG, { slug }, { tag: programTag(slug) }),
+    sanityFetch<HomePageProgram[] | null>(HOME_PAGE_PROGRAMS_QUERY, {}, { tag: homePageTag }),
+  ])
 
   if (!data) return notFound()
 
-  return <ProgramLayout data={data} />
+  const otherPrograms = (homePrograms ?? []).filter((program) => program._id !== data._id)
+
+  return <ProgramLayout data={data} otherPrograms={otherPrograms} />
 }

--- a/apps/web/src/components/program-layout.tsx
+++ b/apps/web/src/components/program-layout.tsx
@@ -6,12 +6,15 @@ import { SanityImage } from '@/components/sanity-image'
 import { DecorativeVideo } from '@/components/decorative-video'
 import { Button } from '@/components/ui/button'
 import { FullBleedCarousel } from '@/components/full-bleed-carousel'
+import { ProgramsSection } from '@/components/programs-section'
 import { gridCols } from '@/lib/grid-columns'
 import { cn } from '@/lib/utils'
 import type { Program, ProgramMove, ProgramProof } from '@/sanity/queries/program-queries'
+import type { HomePageProgram } from '@/sanity/queries/home-page-queries'
 
 interface ProgramLayoutProps {
   data: Program
+  otherPrograms?: HomePageProgram[]
 }
 
 function TextSection({
@@ -217,7 +220,7 @@ function CTASection() {
   )
 }
 
-export function ProgramLayout({ data }: ProgramLayoutProps) {
+export function ProgramLayout({ data, otherPrograms }: ProgramLayoutProps) {
   return (
     <PageTemplate
       className="pb-0"
@@ -245,6 +248,13 @@ export function ProgramLayout({ data }: ProgramLayoutProps) {
       {data.moves && data.moves.length > 0 && <HowSection moves={data.moves} />}
 
       <ProofSection intro={data.proofIntro} proofs={data.proofs} />
+
+      <ProgramsSection
+        label="Other strengths"
+        heading="More ways I can help"
+        programs={otherPrograms}
+        className={gridCols.medium}
+      />
 
       <CTASection />
     </PageTemplate>

--- a/apps/web/src/components/programs-section.tsx
+++ b/apps/web/src/components/programs-section.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
 import { gridCols } from '@/lib/grid-columns'
 import { programPath } from '@/lib/program-display'
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 
 type Program = {
@@ -19,6 +20,7 @@ type ProgramsSectionProps = {
   button?: { text?: string; link?: string }
   programs?: Program[]
   footerLink?: { text?: string; link?: string }
+  className?: string
 }
 
 export function ProgramsSection({
@@ -27,6 +29,7 @@ export function ProgramsSection({
   button,
   programs,
   footerLink,
+  className,
 }: ProgramsSectionProps) {
   const [hoveredIndex, setHoveredIndex] = React.useState<number | null>(null)
   const [isDesktop, setIsDesktop] = React.useState(false)
@@ -65,7 +68,7 @@ export function ProgramsSection({
   }
 
   return (
-    <section className={`${gridCols.full} pb-16 md:pb-24`}>
+    <section className={cn(className ?? gridCols.full, 'pb-16 md:pb-24')}>
       <div className="flex flex-col gap-12 md:gap-16">
         {/* Header - using grid system for column width */}
         <div className="grid grid-cols-12">

--- a/apps/web/src/sanity/queries/home-page-queries.ts
+++ b/apps/web/src/sanity/queries/home-page-queries.ts
@@ -58,6 +58,22 @@ export const HOME_PAGE_QUERY = groq`
   }
 `
 
+export const HOME_PAGE_PROGRAMS_QUERY = groq`
+  *[_type == "homePage"][0].programsSection.programs[]->{
+    _id,
+    title,
+    "description": homeListDescription,
+    "slug": slug.current
+  }
+`
+
+export type HomePageProgram = {
+  _id: string
+  title: string
+  description: string
+  slug: string | null
+}
+
 export type HomePage = {
   _id: string
   tagline: string
@@ -75,12 +91,7 @@ export type HomePage = {
     label?: string
     heading?: string
     button?: { text?: string; link?: string }
-    programs?: Array<{
-      _id: string
-      title: string
-      description: string
-      slug: string | null
-    }>
+    programs?: HomePageProgram[]
     footerLink?: { text?: string; link?: string }
   }
   featuredWorkSection?: {


### PR DESCRIPTION
## Summary

- Fetches sibling programs from the home page programmes section and renders a `ProgramsSection` below the proof carousel on each strength detail page
- Extracts `HomePageProgram` type and `HOME_PAGE_PROGRAMS_QUERY` to avoid duplicating the inline type in `HomePage`
- Adds optional `className` prop to `ProgramsSection` so call sites can control the column width

## Test plan

- [ ] Visit a `/strengths/[slug]` page — "Other strengths" section should appear below the proof carousel, listing the other programmes
- [ ] Confirm the current strength is excluded from the list
- [ ] Confirm the section is absent if no other programmes exist
- [ ] Check layout at mobile and desktop widths

## Security notes

None.

## Env changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)