### PR TITLE
Media quality: image Q90, video resolution ceilings, ABR floor, eager heroes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,4 +83,4 @@
 - E2E smoke: `pnpm e2e:smoke`
 - Supabase local: `pnpm db:start | db:stop | db:reset | db:diff` (CLI v2)
 - Sanity studio (CLI): `pnpm sanity:dev | sanity:build | sanity:deploy`
-- Mux admin: `scripts/mux-rotate-gated-to-signed.ts` (dry-run by default), `scripts/mux-enable-static-renditions.ts`
+- Mux admin: `scripts/mux-rotate-gated-to-signed.ts` (dry-run by default), `scripts/mux-enable-static-renditions.ts`, `scripts/mux-audit-quality.ts` (read-only resolution/tier audit)

--- a/MEDIA-QUALITY.md
+++ b/MEDIA-QUALITY.md
@@ -1,6 +1,8 @@
 # Media Quality Audit & Implementation Plan
 
-> Status: **audit only — nothing implemented yet.** Written 2026-06-12 against
+> Status: **image-side code changes implemented** (quality floor 90, hero
+> `sizes` fix, carousel eager-loading, dev upscale warning — see git history);
+> **video work and asset re-exports still pending.** Written 2026-06-12 against
 > branch `refactor/code-cleanup`. Goal: every image and video on the site feels
 > sharp, clear, and premium by default (Apple.com benchmark), with a pipeline
 > that makes that the default rather than something to fight for per-asset.

--- a/MEDIA-QUALITY.md
+++ b/MEDIA-QUALITY.md
@@ -1,0 +1,281 @@
+# Media Quality Audit & Implementation Plan
+
+> Status: **audit only — nothing implemented yet.** Written 2026-06-12 against
+> branch `refactor/code-cleanup`. Goal: every image and video on the site feels
+> sharp, clear, and premium by default (Apple.com benchmark), with a pipeline
+> that makes that the default rather than something to fight for per-asset.
+
+---
+
+## 1. How media currently flows (verified architecture)
+
+**Images (Sanity):** every content image renders through
+`apps/web/src/components/sanity-image.tsx`, which wraps `next/image` with a
+**custom loader** that builds `cdn.sanity.io` URLs directly
+(`urlFor(image).width(w).auto('format').quality(q)`, plus `height + fit('crop')`
+when an aspect ratio is forced). Defaults: `quality = 85`, LQIP blur-up
+placeholder from asset metadata, intrinsic size 2000px (`BASE_WIDTH`).
+
+Because of the custom loader, **the Next.js/Vercel image optimizer is never
+used for Sanity images**. Consequences:
+
+- `images.minimumCacheTTL` in `apps/web/next.config.ts` is a **no-op** for
+  these images (it only governs `/_next/image`). Caching is whatever
+  `cdn.sanity.io` sends — which is fine (immutable, long-lived), but the config
+  comment claims this setting does the caching. Misleading, not harmful.
+- `images.deviceSizes` still matters: it defines the candidate widths Next puts
+  in `srcset`. The current list correctly includes the 1376px content canvas
+  and its 2× (2752).
+- No AVIF: `auto('format')` makes Sanity serve **WebP** to modern browsers.
+  Sanity's image pipeline outputs jpg/png/webp; AVIF is not available through
+  it (verify against current Sanity docs before relying on this).
+
+**Video (Mux):** three layers —
+
+- `mux-content-player.tsx` — `@mux/mux-player-react/lazy`, default
+  `maxResolution: '1440p'`, poster = Mux `thumbnail.jpg` (signed via token
+  claims for gated assets, `fit_mode=preserve` otherwise).
+- `decorative-video.tsx` — wraps the player for autoplay/muted/loop usage,
+  **default `maxResolution: '1080p'`**, mounts the player only after an
+  IntersectionObserver fires (200px rootMargin), `next/dynamic` with
+  `ssr: false`.
+- `decorative-video-player.tsx` / `decorative-video-block.tsx` — page-level
+  hero/cover wrappers; neither passes `maxResolution`, so they inherit the
+  1080p decorative cap.
+
+Studio uploads: `muxInput({ mp4_support: 'standard', max_resolution_tier: '2160p' })`
+in `apps/web/src/app/studio/sanity.config.ts`.
+
+---
+
+## 2. Diagnosis — why media looks blurry or low quality
+
+Ranked by likely visual impact. Two distinct symptom families: **(T) temporal**
+(“blurry at first, improves after a while”) and **(P) persistent** (“never as
+sharp as the source”).
+
+### P1. Full-bleed videos are capped at 1080p — persistent softness (P)
+
+`DecorativeVideo` defaults to `maxResolution: '1080p'` and **every call site
+uses the default**. The homepage hero, case-study cover videos
+(`DecorativeVideoPlayer` via `PageTemplate`), carousel videos, and program hero
+videos all render in the 1376px content canvas — which is **2752 device pixels
+on a 2× display**. A 1920×1080 stream upscaled ~1.4–2.6× across a hero is
+visibly soft, permanently. This is the single biggest “premium feel” gap and
+exactly the kind of thing Apple never does (their hero videos are served at or
+above device resolution).
+
+### P2. Mux ABR ramp-up — videos start blurry, then improve (T)
+
+Mux adaptive streaming begins on a conservative rendition and steps up. With
+autoplay-muted decorative video this means the first seconds of every hero loop
+look soft on each visit. No `minResolution` is set anywhere. Combined with the
+IntersectionObserver + dynamic-import + lazy-player mounting chain, the hero
+video also _starts_ late, so the poster→soft-video→sharp-video sequence is very
+noticeable above the fold.
+
+### P3. Source images smaller than the requested width — browser upscaling (P)
+
+The Sanity CDN **never upscales**: ask for `w=2752` of a 1920px-wide source and
+you get 1920px back, which the browser then stretches to fill 2752 device
+pixels. The component stack does everything right and the result is still soft.
+This is invisible in code review — it is an **asset discipline** problem.
+Full-bleed 16:9 media needs **2752×1548 minimum**; any screenshot exported at
+1440/1920 wide will never be crisp on the 1376px canvas at 2× DPR.
+(`aspectRatio` crops make it stricter: the _cropped_ region must still be
+≥2752px wide.)
+
+### P4. WebP at quality 85 on detailed UI screenshots (P)
+
+Default `quality = 85` (and 80 for program-layout thumbs). WebP at 85 is good
+for photography, but on fine UI text, hairline borders, and smooth gradients it
+produces ringing/smudging that reads as “slightly off” on a design portfolio.
+Heroes already use 90; body/carousel/card images don’t. For a portfolio,
+crisp-first means **90 as the floor** for content imagery.
+
+### P5. LQIP blur-up + heavy files — “blurry for a while” (T)
+
+Every image shows the LQIP blur placeholder until the full asset arrives. With
+2752px WebP files on slower connections that window is long, and for
+**lazy-loaded** images it restarts at scroll time. This is the main driver of
+“images improve after a while.” It is working as designed — the fix is to make
+the swap faster (correct priority, right sizes, modest file sizes), not to
+remove blur-up.
+
+### P6. Above-the-fold media that is not prioritized (T)
+
+- `CaseStudyCarousel` slides are never `priority` — but a carousel is often the
+  first content block on a case study, sitting at/near the fold. The first
+  slide lazy-loads.
+- `ProjectCard` covers (home grid, /work index) are never `priority`; the first
+  row is above the fold on most viewports.
+- Conversely, `ProgramHeroExamples` marks **every** slide `priority`, which
+  preloads off-screen slides and competes with the real LCP image.
+- Hero images on home/page-template/work-list correctly use `priority`
+  (Next emits `fetchpriority="high"` + preload for these — that part is right).
+
+### P7. Pre-2160p Mux assets and encoding tier (P)
+
+`max_resolution_tier: '2160p'` only affects **new** uploads. Any asset uploaded
+before that setting was added is stored at max 1080p, and no `maxResolution`
+prop can recover detail that was never encoded. The plugin config also doesn’t
+pin Mux’s quality level (`video_quality` / legacy `encoding_tier`); the
+account/asset tier should be verified — Mux’s “basic” quality level both caps
+resolution and lowers bitrate noticeably.
+
+### P8. Posters at default resolution/format (minor, P)
+
+Posters use `thumbnail.jpg` with no `width`. Mux then serves the frame at the
+video’s stored resolution — fine for 2160p assets, soft for 1080p ones, and
+JPEG where WebP would hold gradients better. Signed posters bake render params
+into token claims (`fit_mode: 'preserve'` only), so width can’t be tuned per
+call site for gated assets without adding it to the claims.
+
+### P9. Minor CSS/rendering notes (cosmetic)
+
+- `group-hover:scale-[1.025]` on covers: browsers rasterize the layer at
+  pre-transform size and scale on the compositor, so covers go _very slightly_
+  soft during hover (most visible in Safari). At 1.025 it is borderline
+  acceptable; scaling **down** from 1.0 (or pre-scaling the container) avoids it.
+- `sizes="100vw"` on heroes that are actually capped at `--content-max-width`
+  (1376px) over-requests on wide 1× screens (e.g. 1920w file where 1376 is
+  rendered). Wasteful, not blurry — the correct value is
+  `(min-width: 1376px) 1376px, 100vw` (already used by carousel/content blocks).
+- The `sizes="… 1px"` trick for responsively-hidden duplicates
+  (work-case-study-list) is intentional and fine.
+- No raw `<img>`, no CSS `background-image` content media, no non-integer
+  layout sizing issues found. `public/` only holds avatars.
+
+---
+
+## 3. Prioritized implementation plan
+
+### Phase 1 — biggest visible wins (video + above-the-fold)
+
+1. **Raise video ceilings by surface** (`decorative-video.tsx` call sites):
+   - Full-bleed heroes (homepage cover, `DecorativeVideoPlayer`,
+     `DecorativeVideoBlock`, carousel video, program hero): `maxResolution: '2160p'`
+     (or `'1440p'` if bandwidth cost is a concern — see tradeoffs).
+   - Keep `'1080p'` only for small tiles (≤700 CSS px wide, e.g. work-list 16:9
+     panel at ~793px is borderline — use `'1440p'`).
+   - Add `minResolution: '1080p'` on hero/full-bleed decorative video to kill
+     the visible ABR ramp (player supports it).
+2. **Verify Mux asset inventory.** Script (modeled on
+   `scripts/mux-rotate-gated-to-signed.ts`) listing each asset’s
+   `max_stored_resolution`, `video_quality`/`encoding_tier`, and bitrate;
+   re-upload anything stored ≤1080p that renders full-bleed. This is a
+   _content_ fix no code can substitute for.
+3. **Fix priority coverage:**
+   - `CaseStudyCarousel`: accept a `priority` prop; pass `priority` to slide 0
+     when the carousel is the lead block (or unconditionally for slide 0 of
+     above-the-fold carousels).
+   - `ProjectCard`/grids: `priority` for the first visible row (index-based,
+     like `work-case-study-list` already does).
+   - `ProgramHeroExamples`: `priority` only for the initially visible slide.
+4. **Eager-load the homepage hero video**: bypass (or shrink) the
+   IntersectionObserver delay for above-the-fold `DecorativeVideo` instances
+   (e.g. an `eager` prop that mounts immediately), so poster→video swap starts
+   with the page, not after hydration + observer.
+
+### Phase 2 — image quality floor
+
+5. **Raise `DEFAULT_QUALITY` to 90** in `sanity-image.tsx`; remove the now
+   redundant per-call `quality={90}`; keep ≤85 only for small thumbs
+   (program-layout 152px tile). Optionally support `quality={95}` for
+   text-dense screenshots flagged in Sanity (see Phase 3).
+6. **Correct `sizes` on capped heroes**: `100vw` →
+   `(min-width: 1376px) 1376px, 100vw` for the homepage cover and
+   `PageTemplate` cover (saves bytes → faster blur-up swap, P5).
+7. **Posters**: for public assets append `width=<2× rendered>` (and consider
+   `format=webp`) to `thumbnail.jpg` URLs; for signed assets add `width` to the
+   thumbnail token claims in `mux-signing.ts` (`signMuxToken(..., 't', config,
+{ fit_mode: 'preserve', width: … })`).
+
+### Phase 3 — pipeline guardrails (make quality the default)
+
+8. **Low-res asset detection.** The data is already fetched
+   (`metadata.dimensions`): in dev, `console.warn` from `SanityImage` when the
+   source width is below the largest width the `sizes` attr implies at 2× DPR.
+   Optionally a one-off audit script that walks Sanity assets and reports
+   anything below the floor (full-bleed: 2752px) so existing content can be
+   re-exported.
+9. **Document the standard** (Section 4/5 below) in `CLAUDE.md`/`AGENTS.md`
+   pointers + this file; add the pre-upload checklist to the Studio workflow.
+10. **Config hygiene** (`next.config.ts`): fix the `minimumCacheTTL` comment
+    (no-op for custom-loader images; keep it for any future optimizer usage),
+    and note that `deviceSizes` is the srcset source of truth. If Next is
+    upgraded to 16, add `images.qualities` accordingly.
+
+### Explicitly considered and NOT recommended
+
+- **Switching to the Vercel/Next optimizer to gain AVIF.** It would re-encode
+  Sanity’s output, add Vercel image-transform cost/quotas, and put a second
+  lossy step in the chain. WebP at q90 from Sanity’s CDN, with correctly sized
+  sources, already meets the visual bar. Revisit only if Sanity ships AVIF
+  (then it’s a free win via `auto=format`).
+- **Removing LQIP blur-up.** The temporal blur is a loading-state feature;
+  with Phase 1–2 the swap window shrinks to where it reads as polish, not lag.
+
+---
+
+## 4. Recommended media quality standard (site-wide)
+
+**Canvas math:** content max-width is 1376 CSS px → **2752 device px at 2× DPR**
+is the reference target for anything full-bleed.
+
+| Surface                                              | Min source size                                                   | Delivery                                                                                 |
+| ---------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Full-bleed image (hero, carousel, imageBlock `full`) | **2752px wide** (16:9 crop: 2752×1548)                            | WebP q90, srcset via deviceSizes                                                         |
+| Two-column / `wide` images                           | 2000px wide                                                       | WebP q90                                                                                 |
+| Card covers (1:1)                                    | 1100×1100 (550 CSS × 2)                                           | WebP q90                                                                                 |
+| Small thumbs (≤160 CSS px)                           | 2× rendered                                                       | WebP q85                                                                                 |
+| Text-dense UI screenshots                            | 2× rendered, exported PNG                                         | WebP q95 (or PNG if artifacts visible)                                                   |
+| Hero/full-bleed video                                | **2160p master** (min 1440p), high-bitrate export (see checklist) | Mux `max_resolution_tier: 2160p`, playback `maxResolution ≥1440p`, `minResolution 1080p` |
+| Tile/inline video                                    | 1440p master                                                      | playback `maxResolution 1440p`                                                           |
+| Posters                                              | from ≥1440p stored asset                                          | `width` ≥2× rendered, `fit_mode=preserve`                                                |
+
+**Principles:** crisp first, bytes second (portfolio priority); never let the
+browser upscale (source ≥ requested width); above-the-fold media is eager +
+prioritized, below-the-fold is lazy with LQIP; one pipeline (`SanityImage` /
+Mux components) — no bespoke `<img>`/`<video>`.
+
+---
+
+## 5. Pre-upload checklist
+
+**Images**
+
+- [ ] Exported at **2× the largest rendered CSS size** (full-bleed: ≥2752px wide; 16:9 surfaces: the 16:9 crop itself is ≥2752×1548).
+- [ ] Export format: PNG for UI/screenshots/flat colour; highest-quality JPEG for photography. Never pre-compress to WebP — Sanity transcodes.
+- [ ] No scaling artifacts in the source (check at 100% zoom before upload).
+- [ ] After upload, confirm width/height in Studio metadata meets the table above.
+- [ ] Alt text set.
+
+**Video**
+
+- [ ] Master export ≥1440p, ideally 2160p (even for 1080p-ish display — Mux’s top rendition derives from it).
+- [ ] High-bitrate export: ≥20 Mbps at 1080p, ≥45 Mbps at 2160p (H.264/HEVC).
+- [ ] Uploaded through the Studio (inherits `max_resolution_tier: 2160p`).
+- [ ] After processing, check the asset’s `max_stored_resolution` is ≥1440p.
+- [ ] Poster frame: pick a sharp, representative frame (not a motion-blurred one).
+- [ ] Gated content: confirm signed playback still works (ENVIRONMENT.md runbook).
+
+---
+
+## 6. Tradeoffs
+
+| Change                             | Quality gain                                          | Cost                                                                                                                                                                            |
+| ---------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| q85 → q90 WebP                     | Removes ringing on text/gradients                     | ~20–40% larger image payloads → slightly longer blur-up window (mitigated by correct `sizes`)                                                                                   |
+| Video 1080p → 1440p/2160p playback | The single biggest hero upgrade                       | 2–4× streaming bandwidth; Mux delivery cost scales with resolution; users on slow connections buffer more (ABR still protects them — `maxResolution` is a ceiling, not a floor) |
+| `minResolution: 1080p`             | No visible ramp-up                                    | Slower video start on poor connections; possible stalls — apply to decorative loops only, never the gated content player                                                        |
+| More `priority` images             | Above-the-fold sharp immediately                      | Each preload competes for bandwidth; keep to the true LCP candidates (≤2–3 per page)                                                                                            |
+| 2× source floor                    | Eliminates browser upscaling permanently              | Larger uploads + re-export effort for existing assets; Sanity storage growth (trivial at portfolio scale)                                                                       |
+| Staying on Sanity CDN (no AVIF)    | Single lossy step, simple pipeline, immutable caching | ~20–30% larger than AVIF equivalents; acceptable per crisp-first policy                                                                                                         |
+
+**Bottom line:** the components and `srcset`/`sizes` plumbing are largely
+sound. The premium gap comes from (1) videos capped at 1080p on a 2752-device-px
+canvas, (2) sources/posters that don’t respect the 2× floor, (3) an 85-quality
+default on a portfolio, and (4) a handful of above-the-fold media not being
+prioritized. Fix those four and the “Apple.com feel” follows from the existing
+architecture.

--- a/MEDIA-QUALITY.md
+++ b/MEDIA-QUALITY.md
@@ -1,11 +1,16 @@
 # Media Quality Audit & Implementation Plan
 
-> Status: **image-side code changes implemented** (quality floor 90, hero
-> `sizes` fix, carousel eager-loading, dev upscale warning — see git history);
-> **video work and asset re-exports still pending.** Written 2026-06-12 against
-> branch `refactor/code-cleanup`. Goal: every image and video on the site feels
-> sharp, clear, and premium by default (Apple.com benchmark), with a pipeline
-> that makes that the default rather than something to fight for per-asset.
+> Status: **image and video code changes implemented** (image quality floor 90,
+> hero `sizes` fix, carousel eager-loading, dev upscale warning; per-surface
+> video resolution ceilings up to 2160p, `minResolution` ABR floor on
+> decorative loops, eager hero mounting, Studio upload pinned to
+> 2160p/smart-tier — see git history). **Still pending:** re-exporting
+> low-resolution source images (run `pnpm dev` and watch for `[SanityImage]`
+> upscale warnings) and re-uploading pre-2160p Mux assets (run
+> `scripts/mux-audit-quality.ts`). Written 2026-06-12. Goal: every image and
+> video on the site feels sharp, clear, and premium by default (Apple.com
+> benchmark), with a pipeline that makes that the default rather than
+> something to fight for per-asset.
 
 ---
 
@@ -188,10 +193,13 @@ call site for gated assets without adding it to the claims.
 6. **Correct `sizes` on capped heroes**: `100vw` →
    `(min-width: 1376px) 1376px, 100vw` for the homepage cover and
    `PageTemplate` cover (saves bytes → faster blur-up swap, P5).
-7. **Posters**: for public assets append `width=<2× rendered>` (and consider
-   `format=webp`) to `thumbnail.jpg` URLs; for signed assets add `width` to the
-   thumbnail token claims in `mux-signing.ts` (`signMuxToken(..., 't', config,
-{ fit_mode: 'preserve', width: … })`).
+7. **Posters — decided: leave as-is.** Without a `width` param Mux serves the
+   poster frame at the asset's stored resolution, which is the sharpest
+   available variant (and self-heals when low-res assets are re-uploaded at
+   2160p). Adding a `width` cap would only _reduce_ sharpness for 4K assets on
+   retina, and Mux's max thumbnail dimensions would need verifying first.
+   Heavier-than-necessary posters on small tiles are an accepted crisp-first
+   tradeoff; revisit only if poster payload shows up as a real problem.
 
 ### Phase 3 — pipeline guardrails (make quality the default)
 
@@ -234,7 +242,7 @@ is the reference target for anything full-bleed.
 | Text-dense UI screenshots                            | 2× rendered, exported PNG                                         | WebP q95 (or PNG if artifacts visible)                                                   |
 | Hero/full-bleed video                                | **2160p master** (min 1440p), high-bitrate export (see checklist) | Mux `max_resolution_tier: 2160p`, playback `maxResolution ≥1440p`, `minResolution 1080p` |
 | Tile/inline video                                    | 1440p master                                                      | playback `maxResolution 1440p`                                                           |
-| Posters                                              | from ≥1440p stored asset                                          | `width` ≥2× rendered, `fit_mode=preserve`                                                |
+| Posters                                              | from ≥1440p stored asset                                          | served at stored resolution, `fit_mode=preserve`                                         |
 
 **Principles:** crisp first, bytes second (portfolio priority); never let the
 browser upscale (source ≥ requested width); above-the-fold media is eager +

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,9 +2,12 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   images: {
-    // Exact canvas size (1376) and retina (2752) + standards
+    // srcset candidate widths for ALL next/image usage, including the custom
+    // Sanity loader: exact canvas size (1376) and retina (2752) + standards.
     deviceSizes: [640, 750, 828, 1080, 1200, 1376, 1920, 2048, 2752, 3840],
-    // Sanity URLs are immutable per content version; cache aggressively at the edge.
+    // Only applies to /_next/image (default loader). Sanity images bypass it
+    // via the custom loader in sanity-image.tsx and rely on cdn.sanity.io's
+    // own immutable caching instead.
     minimumCacheTTL: 60 * 60 * 24 * 30,
     // Allow Sanity CDN and Mux thumbnails for next/image
     remotePatterns: [

--- a/apps/web/src/app/(website)/page.tsx
+++ b/apps/web/src/app/(website)/page.tsx
@@ -84,10 +84,9 @@ export default async function Home() {
             <SanityImage
               image={data.coverMedia.image}
               className="w-full h-full object-cover"
-              sizes="100vw"
+              sizes="(min-width: 1376px) 1376px, 100vw"
               aspectRatio="16/9"
               priority
-              quality={90}
             />
           ) : data.coverMedia.type === 'video' && data.coverMedia.video?.asset?.playbackId ? (
             <DecorativeVideoBlock playbackId={data.coverMedia.video.asset.playbackId} />

--- a/apps/web/src/app/(website)/page.tsx
+++ b/apps/web/src/app/(website)/page.tsx
@@ -89,7 +89,12 @@ export default async function Home() {
               priority
             />
           ) : data.coverMedia.type === 'video' && data.coverMedia.video?.asset?.playbackId ? (
-            <DecorativeVideoBlock playbackId={data.coverMedia.video.asset.playbackId} />
+            <DecorativeVideoBlock
+              playbackId={data.coverMedia.video.asset.playbackId}
+              maxResolution="2160p"
+              minResolution="1080p"
+              eager
+            />
           ) : (
             // Fallback placeholder if media type is selected but no asset uploaded
             <div className="w-full h-full bg-secondary" />

--- a/apps/web/src/app/studio/sanity.config.ts
+++ b/apps/web/src/app/studio/sanity.config.ts
@@ -52,7 +52,11 @@ export default defineConfig({
           ]),
     }),
 
-    muxInput({ mp4_support: 'standard', max_resolution_tier: '2160p' }),
+    // Reason: 2160p storage requires the smart encoding tier — pin it rather
+    // than relying on the Mux account default (basic would cap resolution AND
+    // bitrate). Assets uploaded before these settings stay at their original
+    // tier; audit with scripts/mux-audit-quality.ts.
+    muxInput({ mp4_support: 'standard', max_resolution_tier: '2160p', encoding_tier: 'smart' }),
     media(),
     visionTool({
       defaultApiVersion: '2025-01-01',

--- a/apps/web/src/components/case-study-carousel.tsx
+++ b/apps/web/src/components/case-study-carousel.tsx
@@ -62,6 +62,8 @@ export function CaseStudyCarousel({ items, title, description }: CaseStudyCarous
                       tokens={item.video?.asset?.tokens}
                       className="w-full h-full"
                       videoClassName="object-cover"
+                      maxResolution="2160p"
+                      minResolution="1080p"
                     />
                   )}
                 </div>

--- a/apps/web/src/components/case-study-carousel.tsx
+++ b/apps/web/src/components/case-study-carousel.tsx
@@ -51,9 +51,6 @@ export function CaseStudyCarousel({ items, title, description }: CaseStudyCarous
                       className="w-full h-full object-cover"
                       sizes="(min-width: 1376px) 1376px, 100vw"
                       aspectRatio="16/9"
-                      // Reason: Embla translates slides out of the viewport, so
-                      // native lazy-loading would only fetch them mid-transition
-                      // and every slide change would show a blur-up flash.
                       loading="eager"
                     />
                   ) : (

--- a/apps/web/src/components/case-study-carousel.tsx
+++ b/apps/web/src/components/case-study-carousel.tsx
@@ -51,6 +51,10 @@ export function CaseStudyCarousel({ items, title, description }: CaseStudyCarous
                       className="w-full h-full object-cover"
                       sizes="(min-width: 1376px) 1376px, 100vw"
                       aspectRatio="16/9"
+                      // Reason: Embla translates slides out of the viewport, so
+                      // native lazy-loading would only fetch them mid-transition
+                      // and every slide change would show a blur-up flash.
+                      loading="eager"
                     />
                   ) : (
                     <DecorativeVideo

--- a/apps/web/src/components/content-block.tsx
+++ b/apps/web/src/components/content-block.tsx
@@ -94,6 +94,8 @@ export function ContentBlock({ block, layout = 'max-width' }: ContentBlockProps)
             aspectRatio={block.video?.asset?.aspectRatio}
             title={block.title}
             description={block.description}
+            maxResolution="2160p"
+            minResolution="1080p"
           />
         </div>
       )

--- a/apps/web/src/components/decorative-video-block.tsx
+++ b/apps/web/src/components/decorative-video-block.tsx
@@ -8,6 +8,9 @@ interface DecorativeVideoBlockProps {
   title?: string
   description?: string
   aspectRatio?: string
+  maxResolution?: import('@/components/mux-content-player').MuxMaxResolution
+  minResolution?: import('@/components/mux-content-player').MuxMinResolution
+  eager?: boolean
 }
 
 export function DecorativeVideoBlock({
@@ -16,10 +19,20 @@ export function DecorativeVideoBlock({
   title,
   description,
   aspectRatio,
+  maxResolution,
+  minResolution,
+  eager,
 }: DecorativeVideoBlockProps) {
   return (
     <section className="w-full space-y-3 max-w-[var(--content-max-width)] mx-auto">
-      <DecorativeVideoPlayer playbackId={playbackId} tokens={tokens} aspectRatio={aspectRatio} />
+      <DecorativeVideoPlayer
+        playbackId={playbackId}
+        tokens={tokens}
+        aspectRatio={aspectRatio}
+        maxResolution={maxResolution}
+        minResolution={minResolution}
+        eager={eager}
+      />
       {(title || description) && (
         <div className="mx-auto max-w-[592px]">
           {title && <h3 className="text-xl font-semibold">{title}</h3>}

--- a/apps/web/src/components/decorative-video-player.tsx
+++ b/apps/web/src/components/decorative-video-player.tsx
@@ -11,6 +11,9 @@ interface DecorativeVideoPlayerProps {
   tokens?: import('@/components/mux-content-player').MuxPlaybackTokens
   className?: string
   aspectRatio?: string
+  maxResolution?: import('@/components/mux-content-player').MuxMaxResolution
+  minResolution?: import('@/components/mux-content-player').MuxMinResolution
+  eager?: boolean
 }
 
 function toCssAspectRatio(ratio?: string): string {
@@ -25,6 +28,9 @@ export function DecorativeVideoPlayer({
   tokens,
   className,
   aspectRatio,
+  maxResolution,
+  minResolution,
+  eager,
 }: DecorativeVideoPlayerProps) {
   const [isPlaying, setIsPlaying] = React.useState(true)
   const videoRef = React.useRef<HTMLVideoElement>(null)
@@ -50,6 +56,9 @@ export function DecorativeVideoPlayer({
         ref={videoRef}
         playbackId={playbackId}
         tokens={tokens}
+        maxResolution={maxResolution}
+        minResolution={minResolution}
+        eager={eager}
         className="absolute inset-0 h-full w-full"
         videoClassName="block h-full w-full object-cover"
       />

--- a/apps/web/src/components/decorative-video.tsx
+++ b/apps/web/src/components/decorative-video.tsx
@@ -14,19 +14,36 @@ export interface DecorativeVideoProps {
   poster?: string
   className?: string
   videoClassName?: string
-  maxResolution?: '720p' | '1080p' | '1440p' | '2160p'
+  maxResolution?: import('@/components/mux-content-player').MuxMaxResolution
+  minResolution?: import('@/components/mux-content-player').MuxMinResolution
+  /**
+   * Mount the player immediately instead of waiting for the
+   * IntersectionObserver — for above-the-fold heroes, where waiting for
+   * hydration + intersection delays the poster→video swap.
+   */
+  eager?: boolean
 }
 
 export const DecorativeVideo = React.forwardRef<HTMLVideoElement | null, DecorativeVideoProps>(
   function DecorativeVideo(
-    { playbackId, tokens, poster, className, videoClassName, maxResolution = '1080p' },
+    {
+      playbackId,
+      tokens,
+      poster,
+      className,
+      videoClassName,
+      maxResolution = '1080p',
+      minResolution,
+      eager = false,
+    },
     ref,
   ) {
     const containerRef = React.useRef<HTMLDivElement>(null)
 
-    const [hasBeenVisible, setHasBeenVisible] = React.useState(false)
+    const [hasBeenVisible, setHasBeenVisible] = React.useState(eager)
 
     React.useEffect(() => {
+      if (eager) return
       const container = containerRef.current
       if (!container) return
       const observer = new IntersectionObserver(
@@ -40,7 +57,7 @@ export const DecorativeVideo = React.forwardRef<HTMLVideoElement | null, Decorat
       )
       observer.observe(container)
       return () => observer.disconnect()
-    }, [])
+    }, [eager])
 
     return (
       <div ref={containerRef} className={className}>
@@ -55,6 +72,7 @@ export const DecorativeVideo = React.forwardRef<HTMLVideoElement | null, Decorat
             loop
             controls={false}
             maxResolution={maxResolution}
+            minResolution={minResolution}
             className={videoClassName}
           />
         ) : null}

--- a/apps/web/src/components/mux-content-player.tsx
+++ b/apps/web/src/components/mux-content-player.tsx
@@ -10,6 +10,9 @@ export interface MuxPlaybackTokens {
   storyboard?: string
 }
 
+export type MuxMaxResolution = '720p' | '1080p' | '1440p' | '2160p'
+export type MuxMinResolution = '480p' | '540p' | '720p' | '1080p' | '1440p' | '2160p'
+
 export interface MuxContentPlayerProps {
   playbackId: string
   /** Required for assets with a signed playback policy; omit for public assets. */
@@ -21,7 +24,13 @@ export interface MuxContentPlayerProps {
   muted?: boolean
   loop?: boolean
   controls?: boolean
-  maxResolution?: '720p' | '1080p' | '1440p' | '2160p'
+  maxResolution?: MuxMaxResolution
+  /**
+   * ABR floor — keeps Mux from starting on a soft low rendition. Only set this
+   * on decorative loops; the gated content player must stay adaptive so it
+   * never stalls behind user-initiated playback.
+   */
+  minResolution?: MuxMinResolution
 }
 
 export const MuxContentPlayer = React.forwardRef<HTMLVideoElement | null, MuxContentPlayerProps>(
@@ -36,7 +45,10 @@ export const MuxContentPlayer = React.forwardRef<HTMLVideoElement | null, MuxCon
       muted = false,
       loop = false,
       controls = true,
-      maxResolution = '1440p',
+      // Reason: content videos render in the 1376px canvas = 2752 device px on
+      // retina; a 1440p ceiling leaves them permanently soft there.
+      maxResolution = '2160p',
+      minResolution,
     },
     ref,
   ) {
@@ -57,6 +69,7 @@ export const MuxContentPlayer = React.forwardRef<HTMLVideoElement | null, MuxCon
         title={title}
         streamType="on-demand"
         maxResolution={maxResolution}
+        minResolution={minResolution}
         autoPlay={autoPlay ? 'muted' : false}
         muted={muted}
         loop={loop}

--- a/apps/web/src/components/page-template.tsx
+++ b/apps/web/src/components/page-template.tsx
@@ -91,9 +91,8 @@ export function PageTemplate({
                 image={coverMedia.image}
                 className="w-full h-auto object-cover max-h-[90vh] rounded-[8px]"
                 priority
-                sizes="100vw"
+                sizes="(min-width: 1376px) 1376px, 100vw"
                 aspectRatio="auto"
-                quality={90}
               />
             ) : null}
           </section>

--- a/apps/web/src/components/page-template.tsx
+++ b/apps/web/src/components/page-template.tsx
@@ -85,6 +85,9 @@ export function PageTemplate({
               <DecorativeVideoPlayer
                 playbackId={coverMedia.video.asset.playbackId}
                 aspectRatio={coverMedia.video.asset.aspectRatio}
+                maxResolution="2160p"
+                minResolution="1080p"
+                eager
               />
             ) : coverMedia.type === 'image' && coverMedia.image ? (
               <SanityImage

--- a/apps/web/src/components/program-hero-examples.tsx
+++ b/apps/web/src/components/program-hero-examples.tsx
@@ -26,7 +26,7 @@ export function ProgramHeroExamples({ examples }: ProgramHeroExamplesProps) {
     ) ?? []
   if (validExamples.length === 0) return null
 
-  const slideInner = (example: ValidProgramHeroExample) => {
+  const slideInner = (example: ValidProgramHeroExample, index: number) => {
     const { study } = example
     const isVideo =
       study.headerMedia?.type === 'video' && study.headerMedia.video?.asset?.playbackId
@@ -51,8 +51,12 @@ export function ProgramHeroExamples({ examples }: ProgramHeroExamplesProps) {
             className="absolute inset-0 w-full h-full object-cover"
             sizes="(min-width: 1376px) 1376px, 100vw"
             aspectRatio="16/9"
-            priority
-            quality={90}
+            // Reason: only the visible slide is an LCP candidate — preloading
+            // every slide competes with it. Later slides still load eagerly so
+            // navigation never shows a blur-up (Embla hides them via transform,
+            // which defeats native lazy-loading anyway).
+            priority={index === 0}
+            loading="eager"
           />
         ) : null}
 
@@ -68,16 +72,16 @@ export function ProgramHeroExamples({ examples }: ProgramHeroExamplesProps) {
   }
 
   if (validExamples.length === 1) {
-    return <div className="rounded-[8px] overflow-hidden">{slideInner(validExamples[0])}</div>
+    return <div className="rounded-[8px] overflow-hidden">{slideInner(validExamples[0], 0)}</div>
   }
 
   return (
     <div className="relative rounded-[8px] overflow-hidden">
       <Carousel setApi={setApi} opts={{ loop: true, align: 'start' }} className="w-full">
         <CarouselContent className="-ml-0">
-          {validExamples.map((example) => (
+          {validExamples.map((example, index) => (
             <CarouselItem key={example.study._id} className="pl-0 basis-full">
-              {slideInner(example)}
+              {slideInner(example, index)}
             </CarouselItem>
           ))}
         </CarouselContent>

--- a/apps/web/src/components/program-hero-examples.tsx
+++ b/apps/web/src/components/program-hero-examples.tsx
@@ -44,6 +44,9 @@ export function ProgramHeroExamples({ examples }: ProgramHeroExamplesProps) {
             playbackId={study.headerMedia!.video!.asset.playbackId}
             className="absolute inset-0 w-full h-full"
             videoClassName="object-cover"
+            maxResolution="2160p"
+            minResolution="1080p"
+            eager={index === 0}
           />
         ) : image?.asset ? (
           <SanityImage

--- a/apps/web/src/components/program-hero-examples.tsx
+++ b/apps/web/src/components/program-hero-examples.tsx
@@ -54,10 +54,6 @@ export function ProgramHeroExamples({ examples }: ProgramHeroExamplesProps) {
             className="absolute inset-0 w-full h-full object-cover"
             sizes="(min-width: 1376px) 1376px, 100vw"
             aspectRatio="16/9"
-            // Reason: only the visible slide is an LCP candidate — preloading
-            // every slide competes with it. Later slides still load eagerly so
-            // navigation never shows a blur-up (Embla hides them via transform,
-            // which defeats native lazy-loading anyway).
             priority={index === 0}
             loading="eager"
           />

--- a/apps/web/src/components/program-layout.tsx
+++ b/apps/web/src/components/program-layout.tsx
@@ -53,6 +53,8 @@ function MoveCardMedia({ move }: { move: ProgramMove }) {
             playbackId={media.video!.asset.playbackId}
             className="absolute inset-0 w-full h-full"
             videoClassName="object-cover"
+            // 152 CSS px tile — even 3× DPR only needs ~456px
+            maxResolution="720p"
           />
         ) : (
           <SanityImage

--- a/apps/web/src/components/program-layout.tsx
+++ b/apps/web/src/components/program-layout.tsx
@@ -53,7 +53,6 @@ function MoveCardMedia({ move }: { move: ProgramMove }) {
             playbackId={media.video!.asset.playbackId}
             className="absolute inset-0 w-full h-full"
             videoClassName="object-cover"
-            // 152 CSS px tile — even 3× DPR only needs ~456px
             maxResolution="720p"
           />
         ) : (

--- a/apps/web/src/components/program-layout.tsx
+++ b/apps/web/src/components/program-layout.tsx
@@ -60,7 +60,7 @@ function MoveCardMedia({ move }: { move: ProgramMove }) {
             className="absolute inset-0 w-full h-full object-cover"
             sizes="(min-width: 768px) 152px, 120px"
             aspectRatio="1/1"
-            quality={80}
+            quality={85}
           />
         )}
       </div>

--- a/apps/web/src/components/sanity-image.tsx
+++ b/apps/web/src/components/sanity-image.tsx
@@ -13,10 +13,14 @@ interface SanityImageProps {
   aspectRatio: AspectRatio
   quality?: number
   priority?: boolean
+  /** Eager-load without the preload hint `priority` adds (e.g. carousel slides). */
+  loading?: 'eager' | 'lazy'
   className?: string
 }
 
-const DEFAULT_QUALITY = 85
+// Reason: crisp-first portfolio policy (see MEDIA-QUALITY.md) — WebP below 90
+// shows ringing on fine UI text and gradients in screenshots.
+const DEFAULT_QUALITY = 90
 const BASE_WIDTH = 2000
 
 function parseRatio(aspectRatio: AspectRatio): number | null {
@@ -27,8 +31,30 @@ function parseRatio(aspectRatio: AspectRatio): number | null {
   return w / h
 }
 
+// Reason: the Sanity CDN never upscales — requesting more pixels than the
+// source has silently falls back to the source size and the *browser* does the
+// upscaling, which is the main cause of soft images. Surface it in dev.
+const warnedAssets = new Set<string>()
+
+function warnIfUpscaled(image: SanityImageType, width: number, ratio: number | null) {
+  if (process.env.NODE_ENV === 'production') return
+  const id = image.asset?._id || image.asset?._ref
+  const dims = image.asset?.metadata?.dimensions
+  if (!id || !dims?.width || warnedAssets.has(id)) return
+  const neededHeight = ratio !== null ? Math.round(width / ratio) : 0
+  if (dims.width < width || (dims.height ?? Infinity) < neededHeight) {
+    warnedAssets.add(id)
+    console.warn(
+      `[SanityImage] ${id}: browser requested ${width}px wide but the source is ` +
+        `${dims.width}×${dims.height ?? '?'} — it will be upscaled and look soft. ` +
+        `Re-export at 2× the rendered CSS size (see MEDIA-QUALITY.md).`,
+    )
+  }
+}
+
 function makeLoader(image: SanityImageType, ratio: number | null) {
   return ({ width, quality }: ImageLoaderProps) => {
+    warnIfUpscaled(image, width, ratio)
     let builder = urlFor(image).width(width).auto('format')
     if (ratio !== null) {
       builder = builder.height(Math.round(width / ratio)).fit('crop')
@@ -44,6 +70,7 @@ function SanityImageImpl({
   aspectRatio,
   quality = DEFAULT_QUALITY,
   priority,
+  loading,
   className,
 }: SanityImageProps) {
   // Reason: asset id as src keeps Next.js' loader-width validator happy
@@ -75,6 +102,7 @@ function SanityImageImpl({
       sizes={sizes}
       className={className}
       priority={priority}
+      loading={priority ? undefined : loading}
       quality={quality}
       placeholder={blurDataURL ? 'blur' : 'empty'}
       blurDataURL={blurDataURL}

--- a/apps/web/src/components/sanity-image.tsx
+++ b/apps/web/src/components/sanity-image.tsx
@@ -18,8 +18,7 @@ interface SanityImageProps {
   className?: string
 }
 
-// Reason: crisp-first portfolio policy (see MEDIA-QUALITY.md) — WebP below 90
-// shows ringing on fine UI text and gradients in screenshots.
+// Reason: WebP below q90 shows ringing on fine UI text and gradients.
 const DEFAULT_QUALITY = 90
 const BASE_WIDTH = 2000
 
@@ -31,9 +30,8 @@ function parseRatio(aspectRatio: AspectRatio): number | null {
   return w / h
 }
 
-// Reason: the Sanity CDN never upscales — requesting more pixels than the
-// source has silently falls back to the source size and the *browser* does the
-// upscaling, which is the main cause of soft images. Surface it in dev.
+// Reason: the CDN silently returns the source size when asked for more pixels;
+// the browser upscales instead. Warn in dev so under-sized assets are caught.
 const warnedAssets = new Set<string>()
 
 function warnIfUpscaled(image: SanityImageType, width: number, ratio: number | null) {

--- a/apps/web/src/components/work-case-study-list.tsx
+++ b/apps/web/src/components/work-case-study-list.tsx
@@ -86,6 +86,8 @@ export function WorkCaseStudyList({
                     <DecorativeVideo
                       playbackId={heroVideoId}
                       className="pointer-events-none absolute inset-0 transition-transform duration-300 ease-out group-hover:scale-[1.025]"
+                      // ~793 CSS px tile = ~1600 device px on retina
+                      maxResolution="1440p"
                     />
                   ) : heroImage ? (
                     <SanityImage

--- a/apps/web/src/components/work-case-study-list.tsx
+++ b/apps/web/src/components/work-case-study-list.tsx
@@ -86,7 +86,6 @@ export function WorkCaseStudyList({
                     <DecorativeVideo
                       playbackId={heroVideoId}
                       className="pointer-events-none absolute inset-0 transition-transform duration-300 ease-out group-hover:scale-[1.025]"
-                      // ~793 CSS px tile = ~1600 device px on retina
                       maxResolution="1440p"
                     />
                   ) : heroImage ? (

--- a/scripts/mux-audit-quality.ts
+++ b/scripts/mux-audit-quality.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+/**
+ * READ-ONLY audit of every Mux asset referenced from Sanity: stored
+ * resolution, encoding tier, and which documents use it.
+ *
+ * Why: `muxInput({ max_resolution_tier: '2160p', encoding_tier: 'smart' })`
+ * only affects NEW uploads. Assets ingested before those settings are stored
+ * at 1080p (or lower) forever — no player `maxResolution` prop can recover
+ * detail that was never encoded. Those assets must be re-uploaded from a
+ * high-resolution master (see MEDIA-QUALITY.md).
+ *
+ * Usage:
+ *   pnpm dlx dotenv-cli -e apps/web/.env.local -- pnpm tsx scripts/mux-audit-quality.ts
+ *
+ * Required env:
+ *   MUX_TOKEN_ID / MUX_TOKEN_SECRET            (falls back to SANITY_STUDIO_MUX_TOKEN_*)
+ *   NEXT_PUBLIC_SANITY_PROJECT_ID / NEXT_PUBLIC_SANITY_DATASET
+ *   SANITY_API_READ_TOKEN                      (query)
+ */
+
+const MUX_TOKEN_ID = process.env.MUX_TOKEN_ID || process.env.SANITY_STUDIO_MUX_TOKEN_ID
+const MUX_TOKEN_SECRET = process.env.MUX_TOKEN_SECRET || process.env.SANITY_STUDIO_MUX_TOKEN_SECRET
+const SANITY_PROJECT_ID = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+const SANITY_DATASET = process.env.NEXT_PUBLIC_SANITY_DATASET
+const SANITY_READ_TOKEN = process.env.SANITY_API_READ_TOKEN
+const SANITY_API_VERSION = 'v2025-01-01'
+
+// Standard from MEDIA-QUALITY.md: full-bleed surfaces need >=1440p stored.
+const MIN_STORED_TIER = 1440
+
+if (!MUX_TOKEN_ID || !MUX_TOKEN_SECRET || !SANITY_PROJECT_ID || !SANITY_DATASET) {
+  console.error('Missing MUX_TOKEN_* or NEXT_PUBLIC_SANITY_* env vars.')
+  process.exit(1)
+}
+
+const muxAuth = `Basic ${Buffer.from(`${MUX_TOKEN_ID}:${MUX_TOKEN_SECRET}`).toString('base64')}`
+const sanityBase = `https://${SANITY_PROJECT_ID}.api.sanity.io/${SANITY_API_VERSION}`
+
+async function sanityQuery<T>(query: string, params: Record<string, unknown> = {}): Promise<T> {
+  const url = new URL(`${sanityBase}/data/query/${SANITY_DATASET}`)
+  url.searchParams.set('query', query)
+  url.searchParams.set('perspective', 'published')
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(`$${key}`, JSON.stringify(value))
+  }
+  const res = await fetch(url, {
+    headers: SANITY_READ_TOKEN ? { Authorization: `Bearer ${SANITY_READ_TOKEN}` } : {},
+  })
+  if (!res.ok) throw new Error(`Sanity query failed: ${res.status} ${await res.text()}`)
+  return ((await res.json()) as { result: T }).result
+}
+
+type MuxAsset = {
+  id: string
+  status?: string
+  resolution_tier?: string
+  max_resolution_tier?: string
+  max_stored_resolution?: string
+  encoding_tier?: string
+  video_quality?: string
+  aspect_ratio?: string
+  duration?: number
+  max_stored_frame_rate?: number
+}
+
+async function getMuxAsset(assetId: string): Promise<MuxAsset> {
+  const res = await fetch(`https://api.mux.com/video/v1/assets/${assetId}`, {
+    headers: { Authorization: muxAuth },
+  })
+  if (!res.ok) throw new Error(`Mux get asset ${assetId} failed: ${res.status} ${await res.text()}`)
+  return ((await res.json()) as { data: MuxAsset }).data
+}
+
+function tierToNumber(tier: string | undefined): number | null {
+  if (!tier) return null
+  const match = /^(\d+)p$/.exec(tier)
+  return match ? Number(match[1]) : null
+}
+
+async function main() {
+  const assetDocs = await sanityQuery<
+    Array<{ _id: string; assetId?: string; playbackId?: string; filename?: string }>
+  >(`*[_type == "mux.videoAsset"]{ _id, assetId, playbackId, filename }`)
+  console.log(`Found ${assetDocs.length} mux.videoAsset documents in Sanity.\n`)
+
+  const belowStandard: string[] = []
+  let failed = 0
+
+  for (const doc of assetDocs) {
+    const referencedBy = await sanityQuery<Array<{ _type: string; title?: string }>>(
+      `*[references($id)]{ _type, title }`,
+      { id: doc._id },
+    )
+    const usage =
+      referencedBy.map((d) => d.title || d._type).join(', ') || '(unreferenced — orphan?)'
+
+    if (!doc.assetId) {
+      console.warn(`! ${doc._id}: no assetId (used by: ${usage})`)
+      failed += 1
+      continue
+    }
+
+    try {
+      const asset = await getMuxAsset(doc.assetId)
+      const stored = asset.resolution_tier || asset.max_stored_resolution || '?'
+      const quality = asset.video_quality || asset.encoding_tier || '?'
+      const storedNum = tierToNumber(asset.resolution_tier)
+      const flag = storedNum !== null && storedNum < MIN_STORED_TIER ? '  ⚠️ BELOW STANDARD' : ''
+      if (flag) belowStandard.push(`${doc.filename || doc.assetId} (stored ${stored}) — ${usage}`)
+
+      console.log(
+        [
+          `${flag ? '⚠️' : '✓'} ${doc.filename || doc.assetId}`,
+          `   stored=${stored} maxTier=${asset.max_resolution_tier ?? '?'} quality=${quality}`,
+          `   aspect=${asset.aspect_ratio ?? '?'} duration=${asset.duration?.toFixed(0) ?? '?'}s fps=${asset.max_stored_frame_rate ?? '?'}`,
+          `   used by: ${usage}`,
+        ].join('\n'),
+      )
+    } catch (err) {
+      failed += 1
+      console.error(`✗ ${doc.assetId}:`, err)
+    }
+  }
+
+  console.log(`\n— Summary —`)
+  console.log(
+    `Assets below the ${MIN_STORED_TIER}p stored-resolution standard: ${belowStandard.length}`,
+  )
+  for (const line of belowStandard) console.log(`  • ${line}`)
+  if (belowStandard.length > 0) {
+    console.log(
+      `\nThese need re-uploading from a >=1440p (ideally 2160p) master via the Studio,\n` +
+        `which now pins max_resolution_tier=2160p + encoding_tier=smart. Player-side\n` +
+        `maxResolution settings cannot recover detail that was never encoded.`,
+    )
+  }
+  if (failed > 0) console.log(`Lookups failed: ${failed}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- **Images**: raise default WebP quality 85 → 90 (fine UI text/gradients show ringing below q90); fix hero `sizes` from `100vw` to `(min-width: 1376px) 1376px, 100vw`; carousel slides load eagerly (Embla transforms defeat native lazy-loading, causing blur-up flashes on every slide change); `ProgramHeroExamples` now only preloads the visible slide instead of all; dev-only console warning when an image source is narrower than what the browser requests (Sanity CDN silently falls back to source size, browser upscales)
- **Videos**: decorative/hero video ceiling raised from 1080p to 2160p on full-canvas surfaces (the 1376px canvas is 2752 device px on retina — 1080p was permanently ~2× upscaled); `minResolution: '1080p'` ABR floor on decorative loops so Mux can't start on a soft low rendition; `eager` prop on `DecorativeVideo` skips IntersectionObserver for above-the-fold heroes; work-list tile capped at 1440p, 152px tile at 720p; Studio upload now pins `encoding_tier: 'smart'` (required for 2160p storage); new `scripts/mux-audit-quality.ts` inventories all Mux assets and flags any stored below 1440p
- **Docs**: `MEDIA-QUALITY.md` — full audit, diagnosis, quality standard table, pre-upload checklist, tradeoffs

## What still needs content work (no code can fix these)

- Run `scripts/mux-audit-quality.ts` to find assets encoded before the 2160p setting existed — those need re-uploading from a high-res master
- Browse with `pnpm dev` and re-export any images the `[SanityImage]` upscale warnings flag

## Test plan

- [ ] Typecheck, lint, unit tests pass (verified locally)
- [ ] Home page hero image/video loads without visible blur-up delay
- [ ] Carousel images don't flash blurry on slide change
- [ ] Case study cover video starts sharper (no ABR ramp from soft rendition)
- [ ] Dev console clean of unexpected warnings (only `[SanityImage]` for genuinely under-sized assets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)