### PR TITLE
feat: /deck short link backed by Sanity singleton

### DIFF
--- a/apps/web/src/app/(website)/deck/route.ts
+++ b/apps/web/src/app/(website)/deck/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { sanityFetch } from '@/sanity/client'
+import { DECK_QUERY, type DeckResult } from '@/sanity/queries/deck-queries'
+
+export const revalidate = 60
+
+export async function GET() {
+  const deck = await sanityFetch<DeckResult>(DECK_QUERY, {}, { tag: 'deck', revalidate: 60 })
+
+  if (!deck?.url) {
+    return new NextResponse('Deck not found', { status: 404 })
+  }
+
+  return NextResponse.redirect(deck.url, { status: 302 })
+}

--- a/apps/web/src/app/studio/sanity.config.ts
+++ b/apps/web/src/app/studio/sanity.config.ts
@@ -49,6 +49,10 @@ export default defineConfig({
               .title('Pages')
               .icon(() => '📄')
               .child(S.documentTypeList('page').title('Pages')),
+            S.listItem()
+              .title('Deck — Short Link')
+              .icon(() => '📎')
+              .child(S.document().schemaType('deck').documentId('deck').title('Deck (Short Link)')),
           ]),
     }),
 
@@ -68,7 +72,9 @@ export default defineConfig({
     types: schemaTypes,
     templates: (templates) =>
       templates.filter(({ schemaType }) =>
-        ['homePage', 'caseStudy', 'program', 'page', 'portfolioAccessProfile'].includes(schemaType),
+        ['homePage', 'caseStudy', 'program', 'page', 'portfolioAccessProfile', 'deck'].includes(
+          schemaType,
+        ),
       ),
   },
 
@@ -82,7 +88,9 @@ export default defineConfig({
     },
     newDocumentOptions: (prev) =>
       prev.filter(({ templateId }) =>
-        ['homePage', 'caseStudy', 'program', 'page', 'portfolioAccessProfile'].includes(templateId),
+        ['homePage', 'caseStudy', 'program', 'page', 'portfolioAccessProfile', 'deck'].includes(
+          templateId,
+        ),
       ),
   },
 

--- a/apps/web/src/sanity/queries/deck-queries.ts
+++ b/apps/web/src/sanity/queries/deck-queries.ts
@@ -1,0 +1,5 @@
+import { groq } from 'next-sanity'
+
+export const DECK_QUERY = groq`*[_type == "deck"][0]{ "url": pdf.asset->url }`
+
+export type DeckResult = { url: string | null } | null

--- a/apps/web/src/sanity/schemas/deck.ts
+++ b/apps/web/src/sanity/schemas/deck.ts
@@ -1,0 +1,26 @@
+import { defineField, defineType } from 'sanity'
+
+export const deck = defineType({
+  name: 'deck',
+  title: 'Deck — Short Link',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'pdf',
+      title: 'Case Studies PDF',
+      type: 'file',
+      options: { accept: 'application/pdf' },
+      validation: (Rule) => Rule.required(),
+      description:
+        'The PDF distributed via the /deck short link. Replace this file whenever you publish a new version — the link stays the same.',
+    }),
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: 'Case Studies Deck',
+        subtitle: 'Shareable short link → /deck',
+      }
+    },
+  },
+})

--- a/apps/web/src/sanity/schemas/index.ts
+++ b/apps/web/src/sanity/schemas/index.ts
@@ -9,6 +9,7 @@ import { homePage } from './home-page'
 import { legalPage } from './legal-page'
 import { portfolioAccessProfile } from './portfolio-access-profile'
 import { program } from './program'
+import { deck } from './deck'
 
 export const schemaTypes = [
   homePage,
@@ -22,4 +23,5 @@ export const schemaTypes = [
   twoColumnImageBlock,
   legalPage,
   portfolioAccessProfile,
+  deck,
 ]


### PR DESCRIPTION
## Summary

- Adds a `deck` Sanity document type (singleton) with a single PDF file field
- Route handler at `/deck` fetches the current PDF URL from Sanity and issues a `302` redirect
- Updating the PDF in Studio propagates within ~60 s — no redeploy needed
- Registers `deck` in the Studio structure sidebar and schema allowlists

## Studio setup required after merge

1. `pnpm sanity:deploy` to publish the updated schema
2. In Studio → **Deck — Short Link**: upload the PDF and publish

## Test plan

- [ ] Visit `/deck` — confirms redirect to the Sanity CDN PDF URL
- [ ] Update the PDF in Studio, wait ~60 s, revisit `/deck` — confirms new URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)