### PR TITLE
perf(web): improve page loading without reducing asset quality

### DIFF
--- a/apps/web/src/app/(website)/page.tsx
+++ b/apps/web/src/app/(website)/page.tsx
@@ -94,6 +94,7 @@ export default async function Home() {
               maxResolution="2160p"
               minResolution="1080p"
               eager
+              priority
             />
           ) : (
             // Fallback placeholder if media type is selected but no asset uploaded

--- a/apps/web/src/app/(website)/strengths/[slug]/page.tsx
+++ b/apps/web/src/app/(website)/strengths/[slug]/page.tsx
@@ -2,8 +2,13 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 
 import { sanityFetch } from '@/sanity/client'
-import { PROGRAM_BY_SLUG, programTag } from '@/sanity/queries/program-queries'
-import type { Program } from '@/sanity/queries/program-queries'
+import {
+  PROGRAM_BY_SLUG,
+  PUBLISHED_PROGRAM_SLUGS,
+  programTag,
+  programsTag,
+} from '@/sanity/queries/program-queries'
+import type { Program, ProgramSlug } from '@/sanity/queries/program-queries'
 import {
   HOME_PAGE_PROGRAMS_QUERY,
   homePageTag,
@@ -11,10 +16,21 @@ import {
 } from '@/sanity/queries/home-page-queries'
 import { ProgramLayout } from '@/components/program-layout'
 
-export const dynamic = 'force-dynamic'
+export const dynamic = 'force-static'
+export const revalidate = 300
 
 type PageProps = {
   params: Promise<{ slug: string }>
+}
+
+export async function generateStaticParams() {
+  const programs = await sanityFetch<ProgramSlug[]>(
+    PUBLISHED_PROGRAM_SLUGS,
+    {},
+    { tag: programsTag },
+  )
+
+  return programs.map(({ slug }) => ({ slug: slug.current }))
 }
 
 export async function generateMetadata(props: PageProps): Promise<Metadata> {

--- a/apps/web/src/app/(website)/strengths/page.tsx
+++ b/apps/web/src/app/(website)/strengths/page.tsx
@@ -7,7 +7,8 @@ import { PUBLISHED_PROGRAMS, programsTag } from '@/sanity/queries/program-querie
 import type { Program } from '@/sanity/queries/program-queries'
 import { programPath } from '@/lib/program-display'
 
-export const dynamic = 'force-dynamic'
+export const dynamic = 'force-static'
+export const revalidate = 300
 
 export const metadata: Metadata = {
   title: 'Strengths',

--- a/apps/web/src/components/decorative-video-block.tsx
+++ b/apps/web/src/components/decorative-video-block.tsx
@@ -11,6 +11,7 @@ interface DecorativeVideoBlockProps {
   maxResolution?: import('@/components/mux-content-player').MuxMaxResolution
   minResolution?: import('@/components/mux-content-player').MuxMinResolution
   eager?: boolean
+  priority?: boolean
 }
 
 export function DecorativeVideoBlock({
@@ -22,6 +23,7 @@ export function DecorativeVideoBlock({
   maxResolution,
   minResolution,
   eager,
+  priority,
 }: DecorativeVideoBlockProps) {
   return (
     <section className="w-full space-y-3 max-w-[var(--content-max-width)] mx-auto">
@@ -32,6 +34,7 @@ export function DecorativeVideoBlock({
         maxResolution={maxResolution}
         minResolution={minResolution}
         eager={eager}
+        priority={priority}
       />
       {(title || description) && (
         <div className="mx-auto max-w-[592px]">

--- a/apps/web/src/components/decorative-video-player.tsx
+++ b/apps/web/src/components/decorative-video-player.tsx
@@ -14,6 +14,7 @@ interface DecorativeVideoPlayerProps {
   maxResolution?: import('@/components/mux-content-player').MuxMaxResolution
   minResolution?: import('@/components/mux-content-player').MuxMinResolution
   eager?: boolean
+  priority?: boolean
 }
 
 function toCssAspectRatio(ratio?: string): string {
@@ -31,6 +32,7 @@ export function DecorativeVideoPlayer({
   maxResolution,
   minResolution,
   eager,
+  priority,
 }: DecorativeVideoPlayerProps) {
   const [isPlaying, setIsPlaying] = React.useState(true)
   const videoRef = React.useRef<HTMLVideoElement>(null)
@@ -59,6 +61,7 @@ export function DecorativeVideoPlayer({
         maxResolution={maxResolution}
         minResolution={minResolution}
         eager={eager}
+        priority={priority}
         className="absolute inset-0 h-full w-full"
         videoClassName="block h-full w-full object-cover"
       />

--- a/apps/web/src/components/decorative-video.tsx
+++ b/apps/web/src/components/decorative-video.tsx
@@ -2,6 +2,8 @@
 
 import * as React from 'react'
 import dynamic from 'next/dynamic'
+import { cn } from '@/lib/utils'
+import { getMuxPosterUrl } from '@/lib/mux-poster'
 
 const MuxContentPlayer = dynamic(
   () => import('@/components/mux-content-player').then((m) => m.MuxContentPlayer),
@@ -16,6 +18,8 @@ export interface DecorativeVideoProps {
   videoClassName?: string
   maxResolution?: import('@/components/mux-content-player').MuxMaxResolution
   minResolution?: import('@/components/mux-content-player').MuxMinResolution
+  /** Expose the hero poster in SSR and load it before mounting the stream. */
+  priority?: boolean
   /**
    * Mount the player immediately instead of waiting for the
    * IntersectionObserver — for above-the-fold heroes, where waiting for
@@ -35,12 +39,25 @@ export const DecorativeVideo = React.forwardRef<HTMLVideoElement | null, Decorat
       maxResolution = '1080p',
       minResolution,
       eager = false,
+      priority = false,
     },
     ref,
   ) {
     const containerRef = React.useRef<HTMLDivElement>(null)
+    const posterRef = React.useRef<HTMLImageElement>(null)
 
     const [hasBeenVisible, setHasBeenVisible] = React.useState(eager)
+    const [isPosterReady, setIsPosterReady] = React.useState(false)
+    const posterUrl = getMuxPosterUrl({
+      playbackId,
+      poster,
+      thumbnailToken: tokens?.thumbnail,
+    })
+
+    React.useEffect(() => {
+      if (!priority) return
+      if (posterRef.current?.complete) setIsPosterReady(true)
+    }, [priority])
 
     React.useEffect(() => {
       if (eager) return
@@ -60,8 +77,25 @@ export const DecorativeVideo = React.forwardRef<HTMLVideoElement | null, Decorat
     }, [eager])
 
     return (
-      <div ref={containerRef} className={className}>
-        {hasBeenVisible ? (
+      <div ref={containerRef} className={cn(priority && 'relative overflow-hidden', className)}>
+        {priority ? (
+          // Keep only true hero LCP candidates in server-rendered HTML. Lazy
+          // videos retain their original player-driven poster behavior.
+          // eslint-disable-next-line @next/next/no-img-element -- Preserve the original Mux asset without a recompression proxy.
+          <img
+            ref={posterRef}
+            src={posterUrl}
+            alt=""
+            aria-hidden="true"
+            loading="eager"
+            fetchPriority="high"
+            decoding="async"
+            className={cn('absolute inset-0 block h-full w-full object-cover', videoClassName)}
+            onLoad={() => setIsPosterReady(true)}
+            onError={() => setIsPosterReady(true)}
+          />
+        ) : null}
+        {hasBeenVisible && (!priority || isPosterReady) ? (
           <MuxContentPlayer
             ref={ref}
             playbackId={playbackId}
@@ -73,7 +107,7 @@ export const DecorativeVideo = React.forwardRef<HTMLVideoElement | null, Decorat
             controls={false}
             maxResolution={maxResolution}
             minResolution={minResolution}
-            className={videoClassName}
+            className={cn(priority && 'absolute inset-0', videoClassName)}
           />
         ) : null}
       </div>

--- a/apps/web/src/components/mux-content-player.tsx
+++ b/apps/web/src/components/mux-content-player.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import MuxPlayerReact from '@mux/mux-player-react/lazy'
 import type { MuxPlayerRefAttributes } from '@mux/mux-player-react'
+import { getMuxPosterUrl } from '@/lib/mux-poster'
 
 export interface MuxPlaybackTokens {
   playback?: string
@@ -54,11 +55,11 @@ export const MuxContentPlayer = React.forwardRef<HTMLVideoElement | null, MuxCon
   ) {
     // Reason: signed thumbnail URLs reject loose query params — render params
     // (fit_mode) are embedded in the token claims instead.
-    const posterUrl =
-      poster ||
-      (tokens?.thumbnail
-        ? `https://image.mux.com/${playbackId}/thumbnail.jpg?token=${tokens.thumbnail}`
-        : `https://image.mux.com/${playbackId}/thumbnail.jpg?fit_mode=preserve`)
+    const posterUrl = getMuxPosterUrl({
+      playbackId,
+      poster,
+      thumbnailToken: tokens?.thumbnail,
+    })
 
     return (
       <MuxPlayerReact

--- a/apps/web/src/lib/fonts.ts
+++ b/apps/web/src/lib/fonts.ts
@@ -19,6 +19,9 @@ export const optimistic = localFont({
 })
 
 export const plain = localFont({
+  // Plain remains available as the Optimistic fallback, but its 16 individual
+  // faces should not all compete with the primary variable font at startup.
+  preload: false,
   src: [
     {
       path: '../fonts/Plain/Plain-Hairline.woff2',

--- a/apps/web/src/lib/mux-poster.ts
+++ b/apps/web/src/lib/mux-poster.ts
@@ -1,0 +1,15 @@
+export function getMuxPosterUrl({
+  playbackId,
+  poster,
+  thumbnailToken,
+}: {
+  playbackId: string
+  poster?: string
+  thumbnailToken?: string
+}): string {
+  if (poster) return poster
+
+  return thumbnailToken
+    ? `https://image.mux.com/${playbackId}/thumbnail.jpg?token=${thumbnailToken}`
+    : `https://image.mux.com/${playbackId}/thumbnail.jpg?fit_mode=preserve`
+}

--- a/apps/web/src/sanity/queries/program-queries.ts
+++ b/apps/web/src/sanity/queries/program-queries.ts
@@ -69,6 +69,16 @@ export const PUBLISHED_PROGRAMS = groq`
   }
 `
 
+export const PUBLISHED_PROGRAM_SLUGS = groq`
+  *[_type == "program" && defined(slug.current)]{
+    slug
+  }
+`
+
+export type ProgramSlug = {
+  slug: { current: string }
+}
+
 export type ProgramHeroExample = {
   study?: {
     _id: string


### PR DESCRIPTION
## Summary

This PR retains three performance experiments that produced measurable improvements without reducing image, video, or font quality:

- prioritize the homepage decorative-video poster so the LCP image is requested immediately
- stop preloading fallback font faces while keeping every font file and CSS face available
- cache the public strengths index and detail routes with five-minute ISR

Experiments that failed their performance or production-render guardrails were rolled back and are not included.

## Measured impact

- Homepage mobile LCP: 10.59s → 7.40s (about 30% faster)
- Mobile LCP across benchmark routes after reducing font preloads: 34–50% faster
- Font transfer during initial load: 716KB → 103KB
- Font preloads: 19 → 3
- Desktop LCP: 0.65–1.24s faster across the tested routes
- Public strengths warm local TTFB: 8.8ms → 2.8ms
- CLS remained unchanged for the retained experiments

## Quality guardrails

- no image-quality settings changed
- no video-resolution or playback-quality ceilings reduced
- fallback fonts remain available; only their eager preload behavior changed
- home, work, and work-detail routes retain their existing dynamic behavior
- only public strengths routes receive ISR caching

## Validation

- production builds completed for the retained experiments
- 22 Vitest tests passed after the strengths caching change
- TypeScript and focused lint checks passed
- Lighthouse medians were compared across repeated mobile and desktop runs
- rejected experiments were fully restored before this branch was pushed