### PR TITLE
feat(web): add cookie consent controls

### DIFF
--- a/apps/web/src/app/(website)/layout.tsx
+++ b/apps/web/src/app/(website)/layout.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider } from '@/components/theme-provider'
 import { AuthProvider } from '@/components/providers/auth-provider'
 import { LoginModalProvider } from '@/components/providers/login-modal-provider'
+import { CookiePreferencesProvider } from '@/components/providers/cookie-preferences-provider'
 import { HeaderWithNavLayout } from '@/components/header-with-nav-layout'
 
 export default function WebsiteLayout({
@@ -17,7 +18,9 @@ export default function WebsiteLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <HeaderWithNavLayout>{children}</HeaderWithNavLayout>
+          <CookiePreferencesProvider>
+            <HeaderWithNavLayout>{children}</HeaderWithNavLayout>
+          </CookiePreferencesProvider>
         </ThemeProvider>
       </LoginModalProvider>
     </AuthProvider>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,8 +4,6 @@ import { plain, optimistic } from '@/lib/fonts'
 import './globals.css'
 
 import { SITE_CONFIG } from '@/lib/constants'
-import { Analytics } from '@vercel/analytics/next'
-import { SpeedInsights } from '@vercel/speed-insights/next'
 
 const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
@@ -38,8 +36,6 @@ export default function RootLayout({
         suppressHydrationWarning
       >
         {children}
-        <Analytics />
-        <SpeedInsights />
       </body>
     </html>
   )

--- a/apps/web/src/components/consent-aware-analytics.tsx
+++ b/apps/web/src/components/consent-aware-analytics.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { Analytics } from '@vercel/analytics/next'
+import { SpeedInsights } from '@vercel/speed-insights/next'
+import { hasAnalyticsConsent } from '@/lib/cookie-preferences'
+
+export function ConsentAwareAnalytics() {
+  return (
+    <>
+      <Analytics beforeSend={(event) => (hasAnalyticsConsent() ? event : null)} />
+      <SpeedInsights beforeSend={(event) => (hasAnalyticsConsent() ? event : null)} />
+    </>
+  )
+}

--- a/apps/web/src/components/cookie-consent-prompt.stories.tsx
+++ b/apps/web/src/components/cookie-consent-prompt.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { CookieConsentPrompt } from './cookie-consent-prompt'
+
+const meta: Meta<typeof CookieConsentPrompt> = {
+  title: 'Components/Cookie Consent Prompt',
+  component: CookieConsentPrompt,
+  args: {
+    onAccept: () => undefined,
+    onReject: () => undefined,
+    onManage: () => undefined,
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Desktop: Story = {}
+
+export const Mobile: Story = {
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+}
+
+export const SaveError: Story = {
+  args: {
+    saveError: 'Your preference could not be saved. Please try again.',
+  },
+}

--- a/apps/web/src/components/cookie-consent-prompt.tsx
+++ b/apps/web/src/components/cookie-consent-prompt.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter } from '@/components/ui/card'
+
+interface CookieConsentPromptProps {
+  saveError?: string
+  onAccept: () => void
+  onReject: () => void
+  onManage: () => void
+}
+
+export function CookieConsentPrompt({
+  saveError,
+  onAccept,
+  onReject,
+  onManage,
+}: CookieConsentPromptProps) {
+  return (
+    <Card
+      role="region"
+      aria-label="Cookie consent"
+      className="fixed inset-x-4 bottom-4 z-40 gap-4 py-4 shadow-none sm:right-6 sm:bottom-6 sm:left-auto sm:w-full sm:max-w-sm"
+    >
+      <CardContent className="space-y-3 px-4">
+        <p className="text-sm leading-5">
+          We use necessary cookies to make this site work. With your permission, we use analytics to
+          improve performance.
+        </p>
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            className="h-auto p-0 text-sm font-normal text-foreground underline decoration-1 underline-offset-4"
+            onClick={onManage}
+          >
+            Manage cookies
+          </Button>
+          <Button
+            asChild
+            variant="link"
+            size="sm"
+            className="h-auto p-0 text-sm font-normal text-foreground underline decoration-1 underline-offset-4"
+          >
+            <Link href="/cookie-policy">Learn more</Link>
+          </Button>
+        </div>
+
+        {saveError ? (
+          <p role="alert" className="text-sm text-destructive">
+            {saveError}
+          </p>
+        ) : null}
+      </CardContent>
+
+      <CardFooter className="grid grid-cols-2 gap-2 px-4">
+        <Button type="button" size="sm" className="w-full text-sm" onClick={onAccept}>
+          Accept analytics
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="w-full text-sm"
+          onClick={onReject}
+        >
+          Reject analytics
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/src/components/cookie-preferences-dialog.stories.tsx
+++ b/apps/web/src/components/cookie-preferences-dialog.stories.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import type { CookieChoices } from '@/lib/cookie-preferences'
+import { CookiePreferencesDialog } from './cookie-preferences-dialog'
+
+const meta: Meta<typeof CookiePreferencesDialog> = {
+  title: 'Components/Cookie Preferences Dialog',
+  component: CookiePreferencesDialog,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function DialogStory({ initialChoices }: { initialChoices: CookieChoices }) {
+  const [open, setOpen] = React.useState(true)
+  const [choices, setChoices] = React.useState(initialChoices)
+
+  return (
+    <CookiePreferencesDialog
+      open={open}
+      choices={choices}
+      onOpenChange={setOpen}
+      onSave={(nextChoices) => {
+        setChoices(nextChoices)
+        setOpen(false)
+      }}
+    />
+  )
+}
+
+export const Default: Story = {
+  render: () => <DialogStory initialChoices={{ analytics: false }} />,
+}
+
+export const AnalyticsEnabled: Story = {
+  render: () => <DialogStory initialChoices={{ analytics: true }} />,
+}
+
+export const Mobile: Story = {
+  render: () => <DialogStory initialChoices={{ analytics: false }} />,
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+}

--- a/apps/web/src/components/cookie-preferences-dialog.tsx
+++ b/apps/web/src/components/cookie-preferences-dialog.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import * as React from 'react'
+import Link from 'next/link'
+import type { CookieChoices } from '@/lib/cookie-preferences'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+
+interface CookiePreferencesDialogProps {
+  open: boolean
+  choices: CookieChoices
+  saveError?: string
+  onOpenChange: (open: boolean) => void
+  onSave: (choices: CookieChoices) => void
+}
+
+export function CookiePreferencesDialog({
+  open,
+  choices,
+  saveError,
+  onOpenChange,
+  onSave,
+}: CookiePreferencesDialogProps) {
+  const [draft, setDraft] = React.useState(choices)
+
+  React.useEffect(() => {
+    if (open) setDraft(choices)
+  }, [choices, open])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto">
+        <DialogHeader className="pr-6 text-left">
+          <DialogTitle>Cookie preferences</DialogTitle>
+          <DialogDescription className="pt-2 leading-6 text-foreground">
+            This website uses cookies and similar technologies to provide essential features and,
+            with your permission, understand site performance. You can change your choice at any
+            time.{' '}
+            <Link
+              href="/cookie-policy"
+              onClick={() => onOpenChange(false)}
+              className="underline decoration-1 underline-offset-4 transition-colors hover:text-muted-foreground"
+            >
+              Learn more
+            </Link>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          <div className="grid grid-cols-[1rem_1fr] gap-x-3">
+            <Checkbox id="cookies-necessary" checked disabled className="mt-1" />
+            <div>
+              <Label htmlFor="cookies-necessary">Strictly necessary</Label>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                These technologies are required for security, authentication, saved preferences, and
+                other essential site functions. They cannot be turned off.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-[1rem_1fr] gap-x-3">
+            <Checkbox
+              id="cookies-analytics"
+              checked={draft.analytics}
+              onCheckedChange={(checked) =>
+                setDraft((current) => ({ ...current, analytics: checked === true }))
+              }
+              className="mt-1"
+            />
+            <div>
+              <Label htmlFor="cookies-analytics">Analytics and performance</Label>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                These technologies help measure how visitors use the site and how well pages and
+                videos perform. They are disabled unless you opt in.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {saveError ? (
+          <p role="alert" className="mb-4 text-sm text-destructive">
+            {saveError}
+          </p>
+        ) : null}
+
+        <DialogFooter>
+          <Button type="button" className="w-full" onClick={() => onSave(draft)}>
+            Save preferences
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -6,11 +6,14 @@ import { usePathname } from 'next/navigation'
 import { SITE_CONFIG } from '@/lib/constants'
 import { isStrengthDetailPath } from '@/lib/program-display'
 import { cn } from '@/lib/utils'
+import { useCookiePreferences } from '@/components/providers/cookie-preferences-provider'
+import { Button } from '@/components/ui/button'
 
 export function Footer() {
   const [year, setYear] = useState<number>(2025)
   const pathname = usePathname()
   const flush = isStrengthDetailPath(pathname)
+  const { openPreferences } = useCookiePreferences()
 
   useEffect(() => {
     setYear(new Date().getFullYear())
@@ -25,12 +28,14 @@ export function Footer() {
               <span>
                 {year} {SITE_CONFIG.name}
               </span>
-              <a
-                href="#"
-                className="font-normal underline decoration-1 underline-offset-4 hover:text-muted-foreground hover:decoration-muted-foreground transition-colors"
+              <Button
+                type="button"
+                variant="link"
+                onClick={openPreferences}
+                className="h-auto rounded-none p-0 font-normal text-foreground underline decoration-1 underline-offset-4 hover:text-muted-foreground hover:decoration-muted-foreground"
               >
                 Manage cookies
-              </a>
+              </Button>
               <Link
                 href="/terms"
                 className="font-normal underline decoration-1 underline-offset-4 hover:text-muted-foreground hover:decoration-muted-foreground transition-colors"

--- a/apps/web/src/components/mux-content-player.tsx
+++ b/apps/web/src/components/mux-content-player.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import MuxPlayerReact from '@mux/mux-player-react/lazy'
 import type { MuxPlayerRefAttributes } from '@mux/mux-player-react'
+import { useCookiePreferences } from '@/components/providers/cookie-preferences-provider'
 
 export interface MuxPlaybackTokens {
   playback?: string
@@ -52,6 +53,8 @@ export const MuxContentPlayer = React.forwardRef<HTMLVideoElement | null, MuxCon
     },
     ref,
   ) {
+    const { analyticsEnabled } = useCookiePreferences()
+
     // Reason: signed thumbnail URLs reject loose query params — render params
     // (fit_mode) are embedded in the token claims instead.
     const posterUrl =
@@ -62,7 +65,10 @@ export const MuxContentPlayer = React.forwardRef<HTMLVideoElement | null, MuxCon
 
     return (
       <MuxPlayerReact
+        key={analyticsEnabled ? 'analytics-enabled' : 'analytics-disabled'}
         ref={ref as React.Ref<MuxPlayerRefAttributes>}
+        disableCookies
+        disableTracking={!analyticsEnabled}
         playbackId={playbackId}
         tokens={tokens}
         poster={posterUrl}

--- a/apps/web/src/components/providers/cookie-preferences-provider.tsx
+++ b/apps/web/src/components/providers/cookie-preferences-provider.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import * as React from 'react'
+import { ConsentAwareAnalytics } from '@/components/consent-aware-analytics'
+import { CookieConsentPrompt } from '@/components/cookie-consent-prompt'
+import { CookiePreferencesDialog } from '@/components/cookie-preferences-dialog'
+import {
+  COOKIE_PREFERENCES_STORAGE_KEY,
+  DEFAULT_COOKIE_CHOICES,
+  OPTIONAL_STORAGE_MANIFEST,
+  createCookiePreferences,
+  hasRevokedConsent,
+  parseCookiePreferences,
+  type CookieChoices,
+} from '@/lib/cookie-preferences'
+
+interface CookiePreferencesContextValue {
+  analyticsEnabled: boolean
+  openPreferences: () => void
+}
+
+const CookiePreferencesContext = React.createContext<CookiePreferencesContextValue | undefined>(
+  undefined,
+)
+
+function clearDisabledCategoryData(choices: CookieChoices) {
+  for (const [category, storage] of Object.entries(OPTIONAL_STORAGE_MANIFEST)) {
+    if (choices[category as keyof CookieChoices]) continue
+
+    for (const cookieName of storage.cookies) {
+      try {
+        document.cookie = `${encodeURIComponent(cookieName)}=; Max-Age=0; Path=/; SameSite=Lax`
+      } catch {
+        // Cookie access is already blocked, which is an acceptable disabled state.
+      }
+    }
+    for (const storageKey of storage.localStorage) {
+      try {
+        localStorage.removeItem(storageKey)
+      } catch {
+        // Optional storage is already inaccessible, which is an acceptable disabled state.
+      }
+    }
+  }
+}
+
+export function CookiePreferencesProvider({ children }: { children: React.ReactNode }) {
+  const [choices, setChoices] = React.useState<CookieChoices>(DEFAULT_COOKIE_CHOICES)
+  const [ready, setReady] = React.useState(false)
+  const [hasSavedPreferences, setHasSavedPreferences] = React.useState(false)
+  const [open, setOpen] = React.useState(false)
+  const [saveError, setSaveError] = React.useState<string>()
+  const choicesRef = React.useRef(choices)
+
+  React.useEffect(() => {
+    let saved = null
+    try {
+      saved = parseCookiePreferences(localStorage.getItem(COOKIE_PREFERENCES_STORAGE_KEY))
+    } catch {
+      // Storage failures intentionally fall back to all optional categories off.
+    }
+
+    const initialChoices = saved?.choices ?? DEFAULT_COOKIE_CHOICES
+    clearDisabledCategoryData(initialChoices)
+    choicesRef.current = initialChoices
+    setChoices(initialChoices)
+    setHasSavedPreferences(saved !== null)
+    setReady(true)
+
+    function handleStorage(event: StorageEvent) {
+      if (event.key !== COOKIE_PREFERENCES_STORAGE_KEY) return
+
+      const nextPreferences = parseCookiePreferences(event.newValue)
+      const nextChoices = nextPreferences?.choices ?? DEFAULT_COOKIE_CHOICES
+      clearDisabledCategoryData(nextChoices)
+
+      if (hasRevokedConsent(choicesRef.current, nextChoices)) {
+        window.location.reload()
+        return
+      }
+
+      choicesRef.current = nextChoices
+      setChoices(nextChoices)
+      setHasSavedPreferences(nextPreferences !== null)
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [])
+
+  const openPreferences = React.useCallback(() => {
+    setSaveError(undefined)
+    setOpen(true)
+  }, [])
+
+  const savePreferences = React.useCallback((nextChoices: CookieChoices) => {
+    const preferences = createCookiePreferences(nextChoices)
+
+    try {
+      localStorage.setItem(COOKIE_PREFERENCES_STORAGE_KEY, JSON.stringify(preferences))
+    } catch {
+      setSaveError('Your preference could not be saved. Please try again.')
+      return
+    }
+
+    const consentWasRevoked = hasRevokedConsent(choicesRef.current, nextChoices)
+    clearDisabledCategoryData(nextChoices)
+    choicesRef.current = nextChoices
+    setChoices(nextChoices)
+    setHasSavedPreferences(true)
+    setSaveError(undefined)
+    setOpen(false)
+
+    // Vercel's injected scripts do not clean themselves up when unmounted. A
+    // reload after withdrawal guarantees the next document never loads them.
+    if (consentWasRevoked) window.location.reload()
+  }, [])
+
+  const contextValue = React.useMemo(
+    () => ({ analyticsEnabled: ready && choices.analytics, openPreferences }),
+    [choices.analytics, openPreferences, ready],
+  )
+
+  return (
+    <CookiePreferencesContext.Provider value={contextValue}>
+      {children}
+      {ready && choices.analytics ? <ConsentAwareAnalytics /> : null}
+      {ready && !hasSavedPreferences && !open ? (
+        <CookieConsentPrompt
+          saveError={saveError}
+          onAccept={() => savePreferences({ analytics: true })}
+          onReject={() => savePreferences({ analytics: false })}
+          onManage={openPreferences}
+        />
+      ) : null}
+      <CookiePreferencesDialog
+        open={open}
+        choices={choices}
+        saveError={saveError}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen)
+          if (nextOpen) setSaveError(undefined)
+        }}
+        onSave={savePreferences}
+      />
+    </CookiePreferencesContext.Provider>
+  )
+}
+
+export function useCookiePreferences() {
+  const context = React.useContext(CookiePreferencesContext)
+  if (!context) {
+    throw new Error('useCookiePreferences must be used within CookiePreferencesProvider')
+  }
+  return context
+}

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -12,7 +12,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-input bg-background shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50',
+      'peer h-4 w-4 shrink-0 rounded-sm border border-input bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50',
       'data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
       className,
     )}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 origin-center gap-4 border bg-background p-6 shadow-lg duration-200 will-change-transform data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 sm:rounded-lg',
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 origin-center gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 will-change-transform data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95',
         className,
       )}
       {...props}

--- a/apps/web/src/lib/cookie-preferences.test.ts
+++ b/apps/web/src/lib/cookie-preferences.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COOKIE_PREFERENCES_STORAGE_KEY,
+  COOKIE_PREFERENCES_VERSION,
+  createCookiePreferences,
+  hasAnalyticsConsent,
+  hasRevokedConsent,
+  parseCookiePreferences,
+} from './cookie-preferences'
+
+const updatedAt = '2026-07-20T12:00:00.000Z'
+
+describe('cookie preferences', () => {
+  it('fails closed when the preference is missing, corrupt, or outdated', () => {
+    expect(parseCookiePreferences(null)).toBeNull()
+    expect(parseCookiePreferences('{bad json')).toBeNull()
+    expect(
+      parseCookiePreferences(
+        JSON.stringify({
+          version: COOKIE_PREFERENCES_VERSION + 1,
+          updatedAt,
+          choices: { analytics: true },
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  it('rejects incomplete or incorrectly typed choices', () => {
+    expect(
+      parseCookiePreferences(
+        JSON.stringify({ version: COOKIE_PREFERENCES_VERSION, updatedAt, choices: {} }),
+      ),
+    ).toBeNull()
+    expect(
+      parseCookiePreferences(
+        JSON.stringify({
+          version: COOKIE_PREFERENCES_VERSION,
+          updatedAt,
+          choices: { analytics: 'yes' },
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  it('creates and parses a versioned preference record', () => {
+    const preferences = createCookiePreferences({ analytics: true }, updatedAt)
+
+    expect(parseCookiePreferences(JSON.stringify(preferences))).toEqual(preferences)
+  })
+
+  it('only reports analytics consent for a valid explicit opt-in', () => {
+    const optedIn = createCookiePreferences({ analytics: true }, updatedAt)
+    const storage = {
+      getItem: (key: string) =>
+        key === COOKIE_PREFERENCES_STORAGE_KEY ? JSON.stringify(optedIn) : null,
+    }
+
+    expect(hasAnalyticsConsent(storage)).toBe(true)
+    expect(hasAnalyticsConsent({ getItem: () => '{invalid' })).toBe(false)
+    expect(hasAnalyticsConsent({ getItem: () => null })).toBe(false)
+    expect(
+      hasAnalyticsConsent({
+        getItem: () => {
+          throw new Error('Storage unavailable')
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('detects optional consent being withdrawn', () => {
+    expect(hasRevokedConsent({ analytics: true }, { analytics: false })).toBe(true)
+    expect(hasRevokedConsent({ analytics: false }, { analytics: true })).toBe(false)
+    expect(hasRevokedConsent({ analytics: false }, { analytics: false })).toBe(false)
+  })
+})

--- a/apps/web/src/lib/cookie-preferences.ts
+++ b/apps/web/src/lib/cookie-preferences.ts
@@ -1,0 +1,83 @@
+export const COOKIE_PREFERENCES_STORAGE_KEY = 'cookie-preferences'
+export const COOKIE_PREFERENCES_VERSION = 1
+
+export const COOKIE_CATEGORY_KEYS = ['analytics'] as const
+
+export type CookieCategory = (typeof COOKIE_CATEGORY_KEYS)[number]
+export type CookieChoices = Record<CookieCategory, boolean>
+
+export interface CookiePreferences {
+  version: number
+  updatedAt: string
+  choices: CookieChoices
+}
+
+export const DEFAULT_COOKIE_CHOICES: CookieChoices = {
+  analytics: false,
+}
+
+export const OPTIONAL_STORAGE_MANIFEST = {
+  analytics: {
+    cookies: ['muxData'],
+    localStorage: ['muxData'],
+  },
+} as const satisfies Record<
+  CookieCategory,
+  { cookies: readonly string[]; localStorage: readonly string[] }
+>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function createCookiePreferences(
+  choices: CookieChoices,
+  updatedAt = new Date().toISOString(),
+): CookiePreferences {
+  return {
+    version: COOKIE_PREFERENCES_VERSION,
+    updatedAt,
+    choices: { ...choices },
+  }
+}
+
+export function parseCookiePreferences(value: string | null): CookiePreferences | null {
+  if (!value) return null
+
+  try {
+    const parsed: unknown = JSON.parse(value)
+    if (!isRecord(parsed) || parsed.version !== COOKIE_PREFERENCES_VERSION) return null
+    if (typeof parsed.updatedAt !== 'string' || Number.isNaN(Date.parse(parsed.updatedAt))) {
+      return null
+    }
+    const parsedChoices = parsed.choices
+    if (!isRecord(parsedChoices)) return null
+    if (!COOKIE_CATEGORY_KEYS.every((key) => typeof parsedChoices[key] === 'boolean')) return null
+
+    return {
+      version: COOKIE_PREFERENCES_VERSION,
+      updatedAt: parsed.updatedAt,
+      choices: {
+        analytics: parsedChoices.analytics as boolean,
+      },
+    }
+  } catch {
+    return null
+  }
+}
+
+export function hasAnalyticsConsent(storage?: Pick<Storage, 'getItem'>): boolean {
+  try {
+    const selectedStorage = storage ?? (typeof window === 'undefined' ? null : window.localStorage)
+    const preferences = selectedStorage
+      ? parseCookiePreferences(selectedStorage.getItem(COOKIE_PREFERENCES_STORAGE_KEY))
+      : null
+    return preferences?.choices.analytics === true
+  } catch {
+    return false
+  }
+}
+
+export function hasRevokedConsent(previous: CookieChoices, next: CookieChoices): boolean {
+  return COOKIE_CATEGORY_KEYS.some((key) => previous[key] && !next[key])
+}

--- a/tests/smoke/cookie-preferences.spec.ts
+++ b/tests/smoke/cookie-preferences.spec.ts
@@ -1,0 +1,287 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const storageKey = 'cookie-preferences'
+const analyticsScriptSelector = [
+  'script[data-sdkn^="@vercel/analytics"]',
+  'script[src*="va.vercel-scripts.com"]',
+  'script[src*="/_vercel/insights"]',
+].join(', ')
+const speedInsightsScriptSelector = [
+  'script[data-sdkn^="@vercel/speed-insights"]',
+  'script[src*="vitals.vercel-insights.com"]',
+  'script[src*="/_vercel/speed-insights"]',
+].join(', ')
+
+function getDialog(page: Page) {
+  return page.getByRole('dialog', { name: 'Cookie preferences' })
+}
+
+function getPrompt(page: Page) {
+  return page.getByRole('region', { name: 'Cookie consent' })
+}
+
+async function openPreferences(page: Page) {
+  const prompt = getPrompt(page)
+  if (await prompt.isVisible()) {
+    await prompt.getByRole('button', { name: 'Manage cookies' }).click()
+  } else {
+    await page.locator('footer').getByRole('button', { name: 'Manage cookies' }).click()
+  }
+  await expect(getDialog(page)).toBeVisible()
+}
+
+async function expectTrackingDisabled(page: Page) {
+  await expect(page.locator(analyticsScriptSelector)).toHaveCount(0)
+  await expect(page.locator(speedInsightsScriptSelector)).toHaveCount(0)
+
+  const muxPlayer = page.locator('mux-player:not([data-mux-player-react-lazy-placeholder])').first()
+  await expect(muxPlayer).toBeAttached({ timeout: 10_000 })
+  await page.evaluate(() => customElements.whenDefined('mux-player'))
+  await expect
+    .poll(() =>
+      muxPlayer.evaluate((element) => ({
+        cookies: Boolean(element.getAttribute('disable-cookies') !== null),
+        tracking: Boolean(element.getAttribute('disable-tracking') !== null),
+      })),
+    )
+    .toEqual({ cookies: true, tracking: true })
+}
+
+test.describe('Cookie preferences', () => {
+  test('opens the Sanity-managed cookie policy from Learn more', async ({ page }) => {
+    await page.goto('/')
+
+    const prompt = getPrompt(page)
+    await expect(prompt).toBeVisible()
+    const learnMore = prompt.getByRole('link', { name: 'Learn more' })
+    await expect(learnMore).toHaveAttribute('href', '/cookie-policy')
+    await learnMore.click()
+
+    await expect(page).toHaveURL(/\/cookie-policy$/)
+    await expect(prompt).toBeVisible()
+    await expect(page.getByRole('heading', { level: 1, name: 'Cookie Policy' })).toBeVisible()
+
+    await page.goBack()
+    await expect(page).toHaveURL(/\/$/)
+    await expect(prompt).toBeVisible()
+  })
+
+  test('hides the prompt while preferences are open and restores it if closed unsaved', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    const prompt = getPrompt(page)
+    await expect(prompt).toBeVisible()
+    await prompt.getByRole('button', { name: 'Manage cookies' }).click()
+    await expect(prompt).toBeHidden()
+    await expect(getDialog(page)).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(getDialog(page)).toBeHidden()
+    await expect(prompt).toBeVisible()
+  })
+
+  test('defaults optional tracking off and persists that choice', async ({ page, context }) => {
+    await context.addCookies([
+      {
+        name: 'muxData',
+        value: 'legacy-viewer-data',
+        url: new URL(process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000').origin,
+      },
+    ])
+    const trackingRequests: string[] = []
+    page.on('request', (request) => {
+      if (/litix\.io|va\.vercel-scripts\.com|vitals\.vercel-insights\.com/.test(request.url())) {
+        trackingRequests.push(request.url())
+      }
+    })
+
+    await page.goto('/')
+
+    const dialog = getDialog(page)
+    await expect(dialog).toBeHidden()
+    await expect(getPrompt(page)).toBeVisible()
+    await expectTrackingDisabled(page)
+    await openPreferences(page)
+    const necessary = dialog.getByRole('checkbox', { name: 'Strictly necessary' })
+    const analytics = dialog.getByRole('checkbox', { name: 'Analytics and performance' })
+    await expect(necessary).toBeChecked()
+    await expect(necessary).toBeDisabled()
+    await expect(analytics).not.toBeChecked()
+
+    await dialog.getByRole('button', { name: 'Save preferences' }).click()
+    await expect(dialog).toBeHidden()
+    await expect(getPrompt(page)).toBeHidden()
+
+    const saved = await page.evaluate(
+      (key) => JSON.parse(localStorage.getItem(key) ?? 'null'),
+      storageKey,
+    )
+    expect(saved).toMatchObject({ version: 1, choices: { analytics: false } })
+
+    await page.reload()
+    await expect(dialog).toBeHidden()
+    await expect(getPrompt(page)).toBeHidden()
+    await expectTrackingDisabled(page)
+    expect(trackingRequests).toEqual([])
+
+    const muxCookie = (await context.cookies()).find((cookie) => cookie.name === 'muxData')
+    expect(muxCookie).toBeUndefined()
+    expect(await page.evaluate(() => localStorage.getItem('muxData'))).toBeNull()
+  })
+
+  test('loads analytics only after opt-in and fully disables it after withdrawal', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/')
+    const dialog = getDialog(page)
+    await expect(dialog).toBeHidden()
+    const prompt = getPrompt(page)
+    await expect(prompt).toBeVisible()
+    await prompt.getByRole('button', { name: 'Accept analytics' }).click()
+    await expect(prompt).toBeHidden()
+    await expect.poll(() => page.locator(analyticsScriptSelector).count()).toBeGreaterThan(0)
+    await expect.poll(() => page.locator(speedInsightsScriptSelector).count()).toBeGreaterThan(0)
+
+    const muxPlayer = page
+      .locator('mux-player:not([data-mux-player-react-lazy-placeholder])')
+      .first()
+    await expect(muxPlayer).toBeAttached({ timeout: 10_000 })
+    await expect
+      .poll(() =>
+        muxPlayer.evaluate((element) => ({
+          cookies: element.hasAttribute('disable-cookies'),
+          tracking: element.hasAttribute('disable-tracking'),
+        })),
+      )
+      .toEqual({ cookies: true, tracking: false })
+
+    await page.locator('footer').getByRole('button', { name: 'Manage cookies' }).click()
+    await expect(dialog).toBeVisible()
+    const analytics = dialog.getByRole('checkbox', { name: 'Analytics and performance' })
+    await analytics.uncheck()
+
+    const reloaded = page.waitForEvent('framenavigated', (frame) => frame === page.mainFrame())
+    await dialog.getByRole('button', { name: 'Save preferences' }).click()
+    await reloaded
+    await page.waitForLoadState('load')
+
+    await expect(dialog).toBeHidden()
+    await expectTrackingDisabled(page)
+    const saved = await page.evaluate(
+      (key) => JSON.parse(localStorage.getItem(key) ?? 'null'),
+      storageKey,
+    )
+    expect(saved).toMatchObject({ version: 1, choices: { analytics: false } })
+    expect((await context.cookies()).find((cookie) => cookie.name === 'muxData')).toBeUndefined()
+  })
+
+  test('saves a first-visit rejection and does not prompt again', async ({ page }) => {
+    await page.goto('/')
+
+    const prompt = getPrompt(page)
+    await expect(prompt).toBeVisible()
+    await expectTrackingDisabled(page)
+    await prompt.getByRole('button', { name: 'Reject analytics' }).click()
+    await expect(prompt).toBeHidden()
+
+    const saved = await page.evaluate(
+      (key) => JSON.parse(localStorage.getItem(key) ?? 'null'),
+      storageKey,
+    )
+    expect(saved).toMatchObject({ version: 1, choices: { analytics: false } })
+
+    await page.reload()
+    await expect(prompt).toBeHidden()
+    await expectTrackingDisabled(page)
+  })
+
+  test('fails closed for corrupt and outdated stored preferences', async ({ page }) => {
+    await page.addInitScript((key) => {
+      localStorage.setItem(
+        key,
+        JSON.stringify({
+          version: 0,
+          updatedAt: new Date().toISOString(),
+          choices: { analytics: true },
+        }),
+      )
+    }, storageKey)
+
+    await page.goto('/')
+    await expect(getDialog(page)).toBeHidden()
+    await expect(getPrompt(page)).toBeVisible()
+    await expectTrackingDisabled(page)
+    await openPreferences(page)
+    await expect(
+      getDialog(page).getByRole('checkbox', { name: 'Analytics and performance' }),
+    ).not.toBeChecked()
+  })
+
+  test('applies consent withdrawal across open tabs', async ({ page, context }) => {
+    await page.goto('/')
+    await getPrompt(page).getByRole('button', { name: 'Accept analytics' }).click()
+    await expect.poll(() => page.locator(analyticsScriptSelector).count()).toBeGreaterThan(0)
+
+    const otherPage = await context.newPage()
+    await otherPage.goto('/')
+    await expect(getDialog(otherPage)).toBeHidden()
+    await otherPage.locator('footer').getByRole('button', { name: 'Manage cookies' }).click()
+    await getDialog(otherPage)
+      .getByRole('checkbox', { name: 'Analytics and performance' })
+      .uncheck()
+
+    const firstTabReloaded = page.waitForEvent(
+      'framenavigated',
+      (frame) => frame === page.mainFrame(),
+    )
+    const secondTabReloaded = otherPage.waitForEvent(
+      'framenavigated',
+      (frame) => frame === otherPage.mainFrame(),
+    )
+    await getDialog(otherPage).getByRole('button', { name: 'Save preferences' }).click()
+    await Promise.all([firstTabReloaded, secondTabReloaded])
+    await Promise.all([page.waitForLoadState('load'), otherPage.waitForLoadState('load')])
+
+    await expectTrackingDisabled(page)
+    await expectTrackingDisabled(otherPage)
+  })
+
+  test('keeps the dialog usable within a mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/')
+
+    const prompt = getPrompt(page)
+    await expect(prompt).toBeVisible()
+    const promptBox = await prompt.boundingBox()
+    expect(promptBox).not.toBeNull()
+    expect(promptBox!.x).toBeGreaterThanOrEqual(0)
+    expect(promptBox!.y).toBeGreaterThanOrEqual(0)
+    expect(promptBox!.x + promptBox!.width).toBeLessThanOrEqual(390)
+    expect(promptBox!.y + promptBox!.height).toBeLessThanOrEqual(844)
+    await expect(prompt.getByRole('button', { name: 'Accept analytics' })).toBeVisible()
+    await expect(prompt.getByRole('button', { name: 'Reject analytics' })).toBeVisible()
+
+    const dialog = getDialog(page)
+    await expect(dialog).toBeHidden()
+    await openPreferences(page)
+    await expect(dialog).toBeVisible()
+    const box = await dialog.boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.x).toBeGreaterThanOrEqual(0)
+    expect(box!.y).toBeGreaterThanOrEqual(0)
+    expect(box!.x + box!.width).toBeLessThanOrEqual(390)
+    expect(box!.y + box!.height).toBeLessThanOrEqual(844)
+    expect(
+      await dialog.evaluate((element) =>
+        Number.parseFloat(window.getComputedStyle(element).borderTopLeftRadius),
+      ),
+    ).toBeGreaterThan(0)
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+    ).toBe(true)
+    await expect(dialog.getByRole('button', { name: 'Save preferences' })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

- add a compact first-visit cookie consent card with Accept, Reject, Manage cookies, and Learn more actions
- connect the footer Manage cookies action to a shared preferences dialog
- persist versioned preferences, fail closed, support cross-tab withdrawal, and clear known optional storage
- load Vercel Analytics, Speed Insights, and Mux tracking only after analytics consent
- add the Sanity cookie-policy link, responsive dialog refinements, and Storybook coverage

## Why

The footer's Manage cookies link was non-functional and optional analytics had no user-facing consent workflow. This provides an explicit, reversible preference flow while keeping necessary site functionality available.

## User impact

First-time visitors can accept or reject analytics in one click, inspect the cookie policy, or configure preferences in the existing design system. Returning visitors keep their saved choice, and analytics remains disabled unless explicitly enabled.

## Validation

- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `pnpm --filter web test` — 27 tests passed
- cookie-preferences Playwright suite — 8 browser tests passed
- Storybook production build
- desktop and 390 × 844 mobile visual checks
