### PR TITLE
fix(web): hide cookie notice while mobile navigation is open

### DIFF
--- a/apps/web/src/app/(website)/layout.tsx
+++ b/apps/web/src/app/(website)/layout.tsx
@@ -2,6 +2,7 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { AuthProvider } from '@/components/providers/auth-provider'
 import { LoginModalProvider } from '@/components/providers/login-modal-provider'
 import { CookiePreferencesProvider } from '@/components/providers/cookie-preferences-provider'
+import { MobileNavigationProvider } from '@/components/providers/mobile-navigation-provider'
 import { HeaderWithNavLayout } from '@/components/header-with-nav-layout'
 
 export default function WebsiteLayout({
@@ -18,9 +19,11 @@ export default function WebsiteLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <CookiePreferencesProvider>
-            <HeaderWithNavLayout>{children}</HeaderWithNavLayout>
-          </CookiePreferencesProvider>
+          <MobileNavigationProvider>
+            <CookiePreferencesProvider>
+              <HeaderWithNavLayout>{children}</HeaderWithNavLayout>
+            </CookiePreferencesProvider>
+          </MobileNavigationProvider>
         </ThemeProvider>
       </LoginModalProvider>
     </AuthProvider>

--- a/apps/web/src/components/header-with-nav-layout.tsx
+++ b/apps/web/src/components/header-with-nav-layout.tsx
@@ -16,10 +16,12 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Footer } from '@/components/footer'
 import { isStrengthDetailPath } from '@/lib/program-display'
+import { useMobileNavigation } from '@/components/providers/mobile-navigation-provider'
 
 export function HeaderWithNavLayout({ children }: { children: React.ReactNode }) {
   const [mounted, setMounted] = React.useState(false)
-  const [navOpen, setNavOpen] = React.useState(false)
+  const [desktopNavOpen, setDesktopNavOpen] = React.useState(false)
+  const { open: mobileNavOpen, setOpen: setMobileNavOpen } = useMobileNavigation()
 
   const { open: loginOpen, setOpen: setLoginOpen, openLogin } = useLoginModal()
   const { user } = useAuth()
@@ -28,6 +30,7 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
   const [atTop, setAtTop] = React.useState(true)
   const lastYRef = React.useRef(0)
   const [isMobile, setIsMobile] = React.useState(false)
+  const navOpen = isMobile ? mobileNavOpen : desktopNavOpen
   React.useEffect(() => setMounted(true), [])
   React.useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -36,15 +39,21 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
 
       const onMobileChange = (e: MediaQueryListEvent) => {
         setIsMobile(!e.matches)
+        if (e.matches) {
+          setMobileNavOpen(false)
+        } else {
+          setDesktopNavOpen(false)
+        }
       }
       mqMobile.addEventListener('change', onMobileChange)
-      setNavOpen(false)
+      setDesktopNavOpen(false)
+      setMobileNavOpen(false)
 
       return () => {
         mqMobile.removeEventListener('change', onMobileChange)
       }
     }
-  }, [])
+  }, [setMobileNavOpen])
 
   // Header show/hide on scroll and transparency at top
   React.useEffect(() => {
@@ -100,7 +109,7 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
                 variant="ghost"
                 size="icon"
                 className="hidden md:inline-flex pointer-events-auto md:absolute md:left-[148px]"
-                onClick={() => setNavOpen((v) => !v)}
+                onClick={() => setDesktopNavOpen((value) => !value)}
               >
                 {navOpen ? (
                   <SideMenuOpen size={20} className="text-zinc-500" />
@@ -118,8 +127,8 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
                 size="icon"
                 className="md:hidden"
                 onClick={() => {
-                  const willOpen = !navOpen
-                  setNavOpen(willOpen)
+                  const willOpen = !mobileNavOpen
+                  setMobileNavOpen(willOpen)
                   // Dispatch custom event on mobile when opening nav
                   if (willOpen && typeof window !== 'undefined') {
                     window.dispatchEvent(new CustomEvent('mobile-nav-opening'))
@@ -166,10 +175,7 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
                 <li>
                   <Link
                     href="/work"
-                    onClick={() => {
-                      if (typeof window !== 'undefined' && window.innerWidth < 1000)
-                        setNavOpen(false)
-                    }}
+                    onClick={() => setMobileNavOpen(false)}
                     className={cn(
                       'group flex w-full items-center gap-3 rounded-md px-4 py-3 md:px-3 md:py-2 text-xl md:text-base font-normal [font-family:var(--font-geist-sans)] transition-colors',
                       pathname === '/work'
@@ -183,10 +189,7 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
                 <li>
                   <Link
                     href="/bio"
-                    onClick={() => {
-                      if (typeof window !== 'undefined' && window.innerWidth < 1000)
-                        setNavOpen(false)
-                    }}
+                    onClick={() => setMobileNavOpen(false)}
                     className={cn(
                       'group flex w-full items-center gap-3 rounded-md px-4 py-3 md:px-3 md:py-2 text-xl md:text-base font-normal [font-family:var(--font-geist-sans)] transition-colors',
                       pathname === '/bio'
@@ -200,10 +203,7 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
                 <li>
                   <Link
                     href="/stories"
-                    onClick={() => {
-                      if (typeof window !== 'undefined' && window.innerWidth < 1000)
-                        setNavOpen(false)
-                    }}
+                    onClick={() => setMobileNavOpen(false)}
                     className={cn(
                       'group flex w-full items-center gap-3 rounded-md px-4 py-3 md:px-3 md:py-2 text-xl md:text-base font-normal [font-family:var(--font-geist-sans)] transition-colors',
                       pathname === '/stories'
@@ -236,7 +236,7 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
         <button
           aria-hidden={!navOpen}
           aria-label="Dismiss navigation overlay"
-          onClick={() => setNavOpen(false)}
+          onClick={() => setMobileNavOpen(false)}
           className={cn(
             'md:hidden fixed left-0 right-0 bottom-0 z-30 transition-opacity duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]',
             hidden ? 'top-0' : 'top-14',

--- a/apps/web/src/components/providers/cookie-preferences-provider.tsx
+++ b/apps/web/src/components/providers/cookie-preferences-provider.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { ConsentAwareAnalytics } from '@/components/consent-aware-analytics'
 import { CookieConsentPrompt } from '@/components/cookie-consent-prompt'
 import { CookiePreferencesDialog } from '@/components/cookie-preferences-dialog'
+import { useMobileNavigation } from '@/components/providers/mobile-navigation-provider'
 import {
   COOKIE_PREFERENCES_STORAGE_KEY,
   DEFAULT_COOKIE_CHOICES,
@@ -45,6 +46,7 @@ function clearDisabledCategoryData(choices: CookieChoices) {
 }
 
 export function CookiePreferencesProvider({ children }: { children: React.ReactNode }) {
+  const { open: mobileNavigationOpen } = useMobileNavigation()
   const [choices, setChoices] = React.useState<CookieChoices>(DEFAULT_COOKIE_CHOICES)
   const [ready, setReady] = React.useState(false)
   const [hasSavedPreferences, setHasSavedPreferences] = React.useState(false)
@@ -125,7 +127,7 @@ export function CookiePreferencesProvider({ children }: { children: React.ReactN
     <CookiePreferencesContext.Provider value={contextValue}>
       {children}
       {ready && choices.analytics ? <ConsentAwareAnalytics /> : null}
-      {ready && !hasSavedPreferences && !open ? (
+      {ready && !hasSavedPreferences && !open && !mobileNavigationOpen ? (
         <CookieConsentPrompt
           saveError={saveError}
           onAccept={() => savePreferences({ analytics: true })}

--- a/apps/web/src/components/providers/mobile-navigation-provider.tsx
+++ b/apps/web/src/components/providers/mobile-navigation-provider.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import * as React from 'react'
+
+interface MobileNavigationContextValue {
+  open: boolean
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+const MobileNavigationContext = React.createContext<MobileNavigationContextValue | undefined>(
+  undefined,
+)
+
+export function MobileNavigationProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false)
+  const value = React.useMemo(() => ({ open, setOpen }), [open])
+
+  return (
+    <MobileNavigationContext.Provider value={value}>{children}</MobileNavigationContext.Provider>
+  )
+}
+
+export function useMobileNavigation() {
+  const context = React.useContext(MobileNavigationContext)
+  if (!context) {
+    throw new Error('useMobileNavigation must be used within MobileNavigationProvider')
+  }
+  return context
+}

--- a/tests/smoke/cookie-preferences.spec.ts
+++ b/tests/smoke/cookie-preferences.spec.ts
@@ -264,6 +264,14 @@ test.describe('Cookie preferences', () => {
     await expect(prompt.getByRole('button', { name: 'Accept analytics' })).toBeVisible()
     await expect(prompt.getByRole('button', { name: 'Reject analytics' })).toBeVisible()
 
+    const navigationToggle = page.getByRole('button', { name: 'Toggle navigation' })
+    await navigationToggle.click()
+    await expect(page.getByRole('link', { name: 'Work', exact: true })).toBeVisible()
+    await expect(prompt).toBeHidden()
+
+    await navigationToggle.click()
+    await expect(prompt).toBeVisible()
+
     const dialog = getDialog(page)
     await expect(dialog).toBeHidden()
     await openPreferences(page)


### PR DESCRIPTION
## Summary

- add shared state for the mobile navigation layer
- temporarily remove the first-visit cookie notice while mobile navigation is open
- restore the notice unchanged when navigation closes
- keep desktop navigation state independent
- add a mobile regression test for the open/close interaction

## Root cause

The cookie notice used `z-40`, while the mobile sidebar used `z-[48]` and rendered the signed-in avatar at its bottom. This left the notice visible inside the open navigation but underneath the avatar. Raising or lowering individual `z-index` values would preserve conflicting interaction layers, so the fix coordinates their visibility through shared navigation state.

## Validation

- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `pnpm --filter web test` — 27 tests passed
- Playwright cookie-preferences suite — 8 tests passed
- manually verified by the product owner at 390px mobile width on `localhost:3333`