### PR TITLE
fix(web): remove duplicate mobile avatar

### DIFF
--- a/apps/web/src/components/header-with-nav-layout.tsx
+++ b/apps/web/src/components/header-with-nav-layout.tsx
@@ -217,16 +217,14 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
               </ul>
             </nav>
 
-            {/* Mobile-only footer action */}
-            <div className="mt-auto md:hidden flex justify-end">
-              {user ? (
-                <UserMenu />
-              ) : (
+            {/* Mobile-only footer action for logged-out users */}
+            {!user && (
+              <div className="mt-auto flex justify-end md:hidden">
                 <Button variant="secondary" size="default" onClick={() => openLogin()}>
                   Log in
                 </Button>
-              )}
-            </div>
+              </div>
+            )}
           </div>
         </aside>
       )}


### PR DESCRIPTION
## What changed

- Keep the authenticated user avatar in the mobile header.
- Render the mobile navigation footer action only for logged-out users.
- Preserve the bottom-right **Log in** button for logged-out users.

## Why

Authenticated users were seeing the same avatar twice: once in the header and once in the bottom-right corner of the open mobile navigation. The sidebar footer rendered `UserMenu` for authenticated users even though the header already owned that control.

## Impact

Logged-in mobile users now see a single avatar in the header. Logged-out behavior is unchanged.

## Validation

- `pnpm --filter web exec eslint src/components/header-with-nav-layout.tsx`
- `pnpm --filter web typecheck`
- `pnpm --filter web test` — 27 tests passed
- Browser smoke test at 390×844 — HTTP 200, content rendered, no Next.js error overlay