### PR TITLE
feat(web): redesign bio page hero

### DIFF
--- a/apps/web/src/app/(website)/[slug]/page.tsx
+++ b/apps/web/src/app/(website)/[slug]/page.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from 'next'
 import { notFound, redirect } from 'next/navigation'
 import { sanityFetch, sanityNoStoreFetch } from '@/sanity/client'
 import { PageTemplate } from '@/components/page-template'
+import { BioPageLayout } from '@/components/bio-page-layout'
 import { LegalPageContent } from '@/components/legal-page-content'
 import type { PortableTextBlock } from '@portabletext/types'
+import { ebGaramond } from '@/lib/fonts'
 import { IMAGE_PROJECTION, MUX_VIDEO_PROJECTION, type SanityImage } from '@/sanity/queries'
 import {
   ACTIVE_PORTFOLIO_ACCESS_PROFILE_BY_SLUG,
@@ -137,15 +139,39 @@ export default async function DynamicPage(props: PageProps) {
         day: 'numeric',
       })
     : undefined
+  const isBio = slug === 'bio'
+  const pageContent = (
+    <LegalPageContent
+      content={page.content}
+      className={isBio ? `${ebGaramond.className} [--text-xl:20px]` : undefined}
+    />
+  )
+
+  if (isBio && page.coverMedia?.type === 'image' && page.coverMedia.image) {
+    return (
+      <BioPageLayout
+        title={page.title}
+        titleClassName={ebGaramond.className}
+        subtitle={page.subtitle}
+        subtitleClassName={ebGaramond.className}
+        image={page.coverMedia.image}
+        metadata={formattedDate}
+      >
+        {pageContent}
+      </BioPageLayout>
+    )
+  }
 
   return (
     <PageTemplate
       title={page.title}
+      titleClassName={isBio ? ebGaramond.className : undefined}
       subtitle={page.subtitle}
+      subtitleClassName={isBio ? ebGaramond.className : undefined}
       coverMedia={page.coverMedia}
       metadata={formattedDate}
     >
-      <LegalPageContent content={page.content} />
+      {pageContent}
     </PageTemplate>
   )
 }

--- a/apps/web/src/components/bio-page-layout.tsx
+++ b/apps/web/src/components/bio-page-layout.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+import { ContentGrid } from '@/components/content-grid'
+import { SanityImage } from '@/components/sanity-image'
+import type { SanityImage as SanityImageType } from '@/sanity/queries'
+
+interface BioPageLayoutProps {
+  title: string
+  titleClassName?: string
+  metadata?: string | string[]
+  subtitle?: string
+  subtitleClassName?: string
+  image: SanityImageType
+  children: ReactNode
+}
+
+function getObjectPosition(image: SanityImageType) {
+  // The fallback follows the portrait in the current bio cover. A Sanity
+  // hotspot set by an editor always takes precedence.
+  const x = image.hotspot?.x ?? 0.65
+  const y = image.hotspot?.y ?? 0
+  return `${Math.round(x * 100)}% ${Math.round(y * 100)}%`
+}
+
+export function BioPageLayout({
+  title,
+  titleClassName,
+  metadata,
+  subtitle,
+  subtitleClassName,
+  image,
+  children,
+}: BioPageLayoutProps) {
+  return (
+    <div className="pb-24">
+      <section
+        data-bio-hero
+        className="relative h-[80svh] min-h-[560px] overflow-hidden bg-black text-white transition-[border-radius] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] md:min-h-[640px]"
+      >
+        <SanityImage
+          image={image}
+          className="absolute inset-0 h-full w-full object-cover"
+          objectPosition={getObjectPosition(image)}
+          priority
+          sizes="100vw"
+          aspectRatio="auto"
+        />
+
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-[linear-gradient(to_top,rgba(0,0,0,0.68)_0%,rgba(0,0,0,0.18)_38%,rgba(0,0,0,0)_65%)]"
+        />
+
+        <header
+          data-bio-hero-copy
+          className="absolute inset-x-0 bottom-0 z-10 flex flex-col items-center px-6 pb-10 text-center text-white md:px-8 md:pb-14 lg:pb-16"
+        >
+          <div className="flex max-w-[760px] flex-col items-center gap-4 md:gap-5">
+            {metadata && (
+              <div className="flex items-center gap-4 text-sm font-normal text-white">
+                {Array.isArray(metadata) ? (
+                  metadata.map((item, index) => <span key={index}>{item}</span>)
+                ) : (
+                  <span>{metadata}</span>
+                )}
+              </div>
+            )}
+
+            <h1
+              className={cn(
+                'mb-0 max-w-[600px] text-balance text-[clamp(36px,9vw,72px)] leading-none tracking-[-1px] text-white [text-shadow:0_2px_24px_rgb(0_0_0_/_0.3)]',
+                titleClassName,
+              )}
+            >
+              {title}
+            </h1>
+
+            {subtitle && (
+              <p
+                className={cn(
+                  'mb-0 max-w-[620px] text-[20px] leading-relaxed text-white [text-shadow:0_1px_16px_rgb(0_0_0_/_0.35)]',
+                  subtitleClassName,
+                )}
+              >
+                {subtitle}
+              </p>
+            )}
+          </div>
+        </header>
+      </section>
+
+      <div className="px-6 pt-16 md:px-8 md:pt-24">
+        <ContentGrid>{children}</ContentGrid>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/header-with-nav-layout.tsx
+++ b/apps/web/src/components/header-with-nav-layout.tsx
@@ -31,6 +31,8 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
   const lastYRef = React.useRef(0)
   const [isMobile, setIsMobile] = React.useState(false)
   const navOpen = isMobile ? mobileNavOpen : desktopNavOpen
+  const isBioPage = pathname === '/bio'
+  const invertHeader = isBioPage && atTop && !navOpen
   React.useEffect(() => setMounted(true), [])
   React.useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -83,9 +85,10 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
       {mounted && (
         <header
           className={cn(
-            'w-full h-14 md:h-16 sticky top-0 z-50 transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform',
+            'w-full h-14 md:h-16 sticky top-0 z-50 transition-[transform,color,background-color] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform',
             hidden ? '-translate-y-full' : 'translate-y-0',
             atTop ? 'bg-transparent' : 'bg-background',
+            invertHeader ? 'text-white' : 'text-foreground',
           )}
         >
           <div className="h-full px-6 md:px-8 flex items-center justify-between">
@@ -94,11 +97,17 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
               <Link
                 href="/"
                 aria-label="Go to home"
-                className="text-foreground hover:text-primary transition-colors"
+                className={cn(
+                  'transition-colors',
+                  invertHeader
+                    ? 'text-white hover:text-white/80'
+                    : 'text-foreground hover:text-primary',
+                )}
               >
                 <Logotype
                   size="2xl"
                   gradient
+                  gradientMode={invertHeader ? 'dark' : 'auto'}
                   showText={false}
                   className="[&_svg]:w-[36px] [&_svg]:h-auto md:[&_svg]:h-[20px]"
                 />
@@ -109,13 +118,22 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
                 aria-label="Toggle navigation"
                 variant="ghost"
                 size="icon"
-                className="hidden md:inline-flex pointer-events-auto md:absolute md:left-[148px]"
+                className={cn(
+                  'hidden md:inline-flex pointer-events-auto md:absolute md:left-[148px]',
+                  invertHeader && 'text-white hover:bg-white/15 hover:text-white',
+                )}
                 onClick={() => setDesktopNavOpen((value) => !value)}
               >
                 {navOpen ? (
-                  <SideMenuOpen size={20} className="text-zinc-500" />
+                  <SideMenuOpen
+                    size={20}
+                    className={invertHeader ? 'text-white' : 'text-zinc-500'}
+                  />
                 ) : (
-                  <SideMenuClosed size={20} className="text-zinc-500" />
+                  <SideMenuClosed
+                    size={20}
+                    className={invertHeader ? 'text-white' : 'text-zinc-500'}
+                  />
                 )}
               </Button>
             </div>
@@ -126,7 +144,10 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
                 aria-label="Toggle navigation"
                 variant="ghost"
                 size="icon"
-                className="md:hidden"
+                className={cn(
+                  'md:hidden',
+                  invertHeader && 'text-white hover:bg-white/15 hover:text-white',
+                )}
                 onClick={() => {
                   const willOpen = !mobileNavOpen
                   setMobileNavOpen(willOpen)
@@ -137,18 +158,27 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
                 }}
               >
                 {navOpen ? (
-                  <SideMenuOpen size={20} className="text-zinc-500" />
+                  <SideMenuOpen
+                    size={20}
+                    className={invertHeader ? 'text-white' : 'text-zinc-500'}
+                  />
                 ) : (
-                  <SideMenuClosed size={20} className="text-zinc-500" />
+                  <SideMenuClosed
+                    size={20}
+                    className={invertHeader ? 'text-white' : 'text-zinc-500'}
+                  />
                 )}
               </Button>
               {user ? (
                 <UserMenu />
               ) : (
                 <Button
-                  className="hidden md:inline-flex"
                   variant="secondary"
                   size="default"
+                  className={cn(
+                    'hidden md:inline-flex',
+                    invertHeader && 'bg-white/15 text-white backdrop-blur-sm hover:bg-white/25',
+                  )}
                   onClick={() => openLogin()}
                 >
                   Log in
@@ -239,17 +269,22 @@ export function HeaderWithNavLayout({ children }: { children: React.ReactNode })
           'flex flex-col flex-1',
           isMobile && 'transform-gpu will-change-transform',
           navOpen ? 'md:ml-[230px]' : 'md:ml-0',
+          navOpen && isBioPage && '[&_[data-bio-hero]]:rounded-bl-[8px]',
         )}
         style={isMobile ? { transform: navOpen ? 'translateX(80vw)' : 'translateX(0)' } : undefined}
       >
         {/* Content Area */}
         <main
           className={cn(
-            'px-6 md:px-8 pt-6 md:pt-8',
-            isStrengthDetailPath(pathname) ? 'pb-0' : 'pb-6 md:pb-8',
+            isBioPage
+              ? '-mt-14 px-0 pt-0 pb-6 md:-mt-16 md:pb-8'
+              : 'px-6 pt-6 pb-6 md:px-8 md:pt-8 md:pb-8',
+            isStrengthDetailPath(pathname) && 'pb-0',
           )}
         >
-          <div className="max-w-[var(--content-max-width)] mx-auto">{children}</div>
+          <div className={isBioPage ? 'max-w-none' : 'max-w-[var(--content-max-width)] mx-auto'}>
+            {children}
+          </div>
         </main>
         <Footer />
       </div>

--- a/apps/web/src/components/page-template.tsx
+++ b/apps/web/src/components/page-template.tsx
@@ -15,10 +15,14 @@ type CoverMedia =
 interface PageTemplateProps {
   /** Page title (uses h2 styling) */
   title: string
+  /** Optional typography class for the title */
+  titleClassName?: string
   /** Optional metadata (e.g., date, category) - displayed with regular weight */
   metadata?: string | string[]
   /** Optional subtitle/lead text */
   subtitle?: string
+  /** Optional typography class for the subtitle */
+  subtitleClassName?: string
   /** Optional cover media (image or video) */
   coverMedia?: CoverMedia
   /** Optional custom cover content rendered in the cover-media area (takes precedence over coverMedia) */
@@ -33,8 +37,10 @@ interface PageTemplateProps {
 
 export function PageTemplate({
   title,
+  titleClassName,
   metadata,
   subtitle,
+  subtitleClassName,
   coverMedia,
   cover,
   children,
@@ -66,10 +72,17 @@ export function PageTemplate({
             </div>
           )}
 
-          <h1>{title}</h1>
+          <h1 className={titleClassName}>{title}</h1>
 
           {subtitle && (
-            <p className="text-xl text-foreground leading-relaxed max-w-prose mt-2">{subtitle}</p>
+            <p
+              className={cn(
+                'text-xl text-foreground leading-relaxed max-w-prose mt-2',
+                subtitleClassName,
+              )}
+            >
+              {subtitle}
+            </p>
           )}
         </header>
       </div>

--- a/apps/web/src/components/sanity-image.tsx
+++ b/apps/web/src/components/sanity-image.tsx
@@ -16,6 +16,7 @@ interface SanityImageProps {
   /** Eager-load without the preload hint `priority` adds (e.g. carousel slides). */
   loading?: 'eager' | 'lazy'
   className?: string
+  objectPosition?: React.CSSProperties['objectPosition']
 }
 
 // Reason: WebP below q90 shows ringing on fine UI text and gradients.
@@ -70,6 +71,7 @@ function SanityImageImpl({
   priority,
   loading,
   className,
+  objectPosition,
 }: SanityImageProps) {
   // Reason: asset id as src keeps Next.js' loader-width validator happy
   // (it compares loader output to src; identical strings trigger a warning).
@@ -99,6 +101,7 @@ function SanityImageImpl({
       height={height}
       sizes={sizes}
       className={className}
+      style={objectPosition ? { objectPosition } : undefined}
       priority={priority}
       loading={priority ? undefined : loading}
       quality={quality}

--- a/apps/web/src/components/ui/logotype.stories.tsx
+++ b/apps/web/src/components/ui/logotype.stories.tsx
@@ -20,6 +20,10 @@ const meta: Meta<typeof Logotype> = {
     showText: {
       control: { type: 'boolean' },
     },
+    gradientMode: {
+      control: { type: 'select' },
+      options: ['auto', 'dark'],
+    },
     text: {
       control: { type: 'text' },
     },
@@ -44,6 +48,14 @@ export const LogoOnly: Story = {
   args: {
     showText: false,
   },
+}
+
+export const DarkModeGradient: Story = {
+  render: () => (
+    <div className="rounded-lg bg-zinc-950 p-6">
+      <Logotype size="2xl" gradient gradientMode="dark" showText={false} />
+    </div>
+  ),
 }
 
 export const Sizes: Story = {
@@ -228,9 +240,10 @@ export const ThemeShowcase: Story = {
     <div className="space-y-8 p-6">
       <h2 className="text-2xl font-bold">Theme Adaptation</h2>
       <p className="text-muted-foreground">
-        The logo automatically adapts to light and dark themes using `fill=&quot;currentColor&quot;`.
+        The logo automatically adapts to light and dark themes using
+        `fill=&quot;currentColor&quot;`.
       </p>
-      
+
       <div className="grid md:grid-cols-2 gap-6">
         <div className="p-6 bg-background border rounded-lg">
           <h3 className="font-semibold mb-4">Light Theme Simulation</h3>
@@ -239,7 +252,7 @@ export const ThemeShowcase: Story = {
             <Logotype size="md" showText={false} className="text-muted-foreground" />
           </div>
         </div>
-        
+
         <div className="p-6 rounded-lg dark bg-background text-foreground">
           <h3 className="font-semibold mb-4">Dark Theme Simulation</h3>
           <div className="space-y-4">

--- a/apps/web/src/components/ui/logotype.tsx
+++ b/apps/web/src/components/ui/logotype.tsx
@@ -41,6 +41,7 @@ interface LogotypeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof logotypeVariants> {
   gradient?: boolean
+  gradientMode?: 'auto' | 'dark'
   showText?: boolean
   text?: string
   href?: string
@@ -51,9 +52,10 @@ const LogoMark = React.forwardRef<
   SVGSVGElement,
   React.SVGProps<SVGSVGElement> & {
     gradient?: boolean
+    gradientMode?: 'auto' | 'dark'
     size: keyof typeof logoSizes
   }
->(({ size, gradient = false, className, ...props }, ref) => {
+>(({ size, gradient = false, gradientMode = 'auto', className, ...props }, ref) => {
   const dimensions = logoSizes[size]
   const gradientId = `logo-gradient-${React.useId().replaceAll(':', '')}`
 
@@ -68,7 +70,9 @@ const LogoMark = React.forwardRef<
       className={cn(
         'flex-shrink-0 transition-colors',
         gradient &&
-          '[--logo-gradient-end:#60606C] [--logo-gradient-start:#09090B] dark:[--logo-gradient-end:#FAFAFA] dark:[--logo-gradient-start:#A1A1AA]',
+          (gradientMode === 'dark'
+            ? '[--logo-gradient-end:#FAFAFA] [--logo-gradient-start:#A1A1AA]'
+            : '[--logo-gradient-end:#60606C] [--logo-gradient-start:#09090B] dark:[--logo-gradient-end:#FAFAFA] dark:[--logo-gradient-start:#A1A1AA]'),
         className,
       )}
       {...props}
@@ -106,6 +110,7 @@ const Logotype = React.forwardRef<HTMLDivElement, LogotypeProps>(
       size = 'md',
       variant = 'default',
       gradient = false,
+      gradientMode = 'auto',
       showText = true,
       text = SITE_CONFIG.name,
       href,
@@ -124,7 +129,7 @@ const Logotype = React.forwardRef<HTMLDivElement, LogotypeProps>(
           ref={ref as any} // eslint-disable-line @typescript-eslint/no-explicit-any
           {...(props as any)} // eslint-disable-line @typescript-eslint/no-explicit-any
         >
-          <LogoMark size={size!} gradient={gradient} />
+          <LogoMark size={size!} gradient={gradient} gradientMode={gradientMode} />
           {showText && <span className="font-inherit leading-none">{text}</span>}
         </a>
       )
@@ -137,7 +142,7 @@ const Logotype = React.forwardRef<HTMLDivElement, LogotypeProps>(
           ref={ref as any} // eslint-disable-line @typescript-eslint/no-explicit-any
           {...(props as any)} // eslint-disable-line @typescript-eslint/no-explicit-any
         >
-          <LogoMark size={size!} gradient={gradient} />
+          <LogoMark size={size!} gradient={gradient} gradientMode={gradientMode} />
           {showText && <span className="font-inherit leading-none">{text}</span>}
         </button>
       )
@@ -145,7 +150,7 @@ const Logotype = React.forwardRef<HTMLDivElement, LogotypeProps>(
 
     return (
       <div className={baseClassName} ref={ref} {...props}>
-        <LogoMark size={size!} gradient={gradient} />
+        <LogoMark size={size!} gradient={gradient} gradientMode={gradientMode} />
         {showText && <span className="font-inherit leading-none">{text}</span>}
       </div>
     )

--- a/apps/web/src/lib/fonts.ts
+++ b/apps/web/src/lib/fonts.ts
@@ -1,4 +1,13 @@
 import localFont from 'next/font/local'
+import { EB_Garamond } from 'next/font/google'
+
+export const ebGaramond = EB_Garamond({
+  weight: 'variable',
+  style: ['normal', 'italic'],
+  subsets: ['latin'],
+  display: 'swap',
+  preload: false,
+})
 
 // VF handles all normal styles; TextRegularIt is used only for italic rendering
 export const optimistic = localFont({


### PR DESCRIPTION
## Summary

- switch the `/bio` title, subtitle, and body copy to EB Garamond while preserving the existing eyebrow typography
- introduce a full-bleed, 80svh bio hero with responsive image focal positioning and a bottom-only readability gradient
- overlay responsive title and subtitle typography on the cover image, including a 36–72px fluid title, `-1px` tracking, and 20px subtitle/body copy
- invert the header over the hero, retain the existing dark-mode logo gradient, and restore readable header controls when navigation opens
- add the 8px hero corner treatment for the open slide-in navigation and preserve mobile content gutters

## Why

The generic page template constrained the bio cover and placed the heading above it, so it could not support the intended editorial hero layout. The initial fixed 7xl title also stopped scaling on narrow screens. This introduces a bio-specific composition while keeping shared components reusable and restoring fluid typography.

## Impact

The `/bio` page now has a more immersive editorial opening, maintains the portrait focal point across viewport sizes, and keeps navigation and body content readable in desktop and mobile states. Other dynamic pages continue using the existing page template.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 27 tests passed
- browser-verified `/bio` at desktop and mobile widths
- browser-verified open/closed navigation logo gradients and no console or framework-overlay errors