### PR TITLE
fix(web): contain case study panel overlays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,4 +54,5 @@ pnpm storybook:web      # Visual checks (the only Storybook)
 - [Sanity]: root `sanity.config.ts` is a re-export of `apps/web/src/app/studio/sanity.config.ts` — edit the embedded one.
 - [Access]: recruiter gating = HMAC cookies + `?k=` link tokens + signed Mux playback; teasers/covers stay public by design.
 - [Testing]: keep crypto/logic in pure modules (no `server-only`/`next/headers`) so Vitest can import them.
+- [Dev]: Dropbox can corrupt `.next` via conflicted copies; set `NEXT_DIST_DIR` to a relative path outside the sync root.
 <!-- Only add genuinely reusable knowledge, not story-specific details -->

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  ...(process.env.NEXT_DIST_DIR ? { distDir: process.env.NEXT_DIST_DIR } : {}),
   images: {
     // srcset candidate widths for ALL next/image usage, including the custom
     // Sanity loader: exact canvas size (1376) and retina (2752) + standards.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -261,6 +261,19 @@
       );
     }
   }
+
+  /**
+   * An open case-study panel turns the page into two real columns. Keep
+   * viewport-bleed carousels inside the remaining content column so their
+   * scrollport and slides do not continue underneath or beyond the panel.
+   */
+  @media (min-width: 768px) {
+    .case-study-panel-open .carousel-bleed {
+      --carousel-edge: 0px;
+      --carousel-inset: 0px;
+      width: 100%;
+    }
+  }
 }
 
 /* ============================================

--- a/apps/web/src/components/case-study-layout.tsx
+++ b/apps/web/src/components/case-study-layout.tsx
@@ -28,7 +28,7 @@ export function CaseStudyLayout({
 }: CaseStudyLayoutProps) {
   const [isPanelOpen, setIsPanelOpen] = React.useState(false)
 
-  const togglePanel = () => setIsPanelOpen(!isPanelOpen)
+  const togglePanel = () => setIsPanelOpen((current) => !current)
 
   React.useEffect(() => {
     const handleNavOpening = () => {
@@ -62,10 +62,18 @@ export function CaseStudyLayout({
   }, [isPanelOpen])
 
   return (
-    <div className="relative min-h-screen flex flex-col md:flex-row">
+    <div
+      data-case-study-layout
+      data-panel-open={isPanelOpen}
+      className={cn(
+        'relative min-h-screen flex flex-col md:flex-row',
+        isPanelOpen && 'case-study-panel-open',
+      )}
+    >
       <div
+        data-case-study-main
         className={cn(
-          'flex-1 transition-all duration-500 ease-in-out w-full',
+          'min-w-0 flex-1 transition-all duration-500 ease-in-out w-full',
           isPanelOpen ? 'md:w-1/2' : 'w-full',
         )}
       >
@@ -91,8 +99,9 @@ export function CaseStudyLayout({
       </div>
 
       <div
+        data-case-study-panel
         className={cn(
-          'hidden md:block transition-all duration-500 ease-in-out bg-background z-50',
+          'hidden md:block transition-all duration-500 ease-in-out bg-background z-30',
           'relative',
           isPanelOpen ? 'min-h-screen w-1/2 opacity-100' : 'w-0 opacity-0 overflow-hidden',
         )}

--- a/tests/smoke/case-study-panel.spec.ts
+++ b/tests/smoke/case-study-panel.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Case study project panel', () => {
+  test('contains full-bleed content and keeps cookie consent above the panel', async ({ page }) => {
+    await page.setViewportSize({ width: 2048, height: 1228 })
+    await page.goto('/work/tap')
+
+    const layout = page.locator('[data-case-study-layout]')
+    const main = layout.locator('[data-case-study-main]')
+    const panel = layout.locator('[data-case-study-panel]')
+    const carousel = main.locator('.carousel-bleed')
+    const prompt = page.getByRole('region', { name: 'Cookie consent' })
+
+    await expect(layout).toHaveAttribute('data-panel-open', 'false')
+    await expect(carousel).toHaveCount(1)
+    await expect(prompt).toBeVisible()
+
+    await page.getByRole('button', { name: 'About the project', exact: true }).click()
+    await expect(layout).toHaveAttribute('data-panel-open', 'true')
+
+    await expect
+      .poll(async () => {
+        const [mainBox, panelBox, carouselBox] = await Promise.all([
+          main.boundingBox(),
+          panel.boundingBox(),
+          carousel.boundingBox(),
+        ])
+
+        if (!mainBox || !panelBox || !carouselBox || panelBox.width === 0) return false
+
+        return carouselBox.x >= mainBox.x - 1 && carouselBox.x + carouselBox.width <= panelBox.x + 1
+      })
+      .toBe(true)
+
+    const carouselMetrics = await carousel.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }))
+    expect(carouselMetrics.scrollWidth).toBeGreaterThan(carouselMetrics.clientWidth)
+
+    const promptIsTopmost = await prompt.evaluate((element) => {
+      const bounds = element.getBoundingClientRect()
+      const inset = 8
+      const points = [
+        [bounds.left + inset, bounds.top + inset],
+        [bounds.right - inset, bounds.top + inset],
+        [bounds.left + inset, bounds.bottom - inset],
+        [bounds.right - inset, bounds.bottom - inset],
+        [bounds.left + bounds.width / 2, bounds.top + bounds.height / 2],
+      ]
+
+      return points.every(([x, y]) => {
+        const topmost = document.elementFromPoint(x, y)
+        return topmost !== null && element.contains(topmost)
+      })
+    })
+
+    expect(promptIsTopmost).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- keep cookie consent above the desktop “About the project” panel
- contain viewport-bleed project carousels within the remaining case-study column while the panel is open
- add smoke coverage for layout geometry, carousel scrolling, and cookie-consent hit-testing
- allow `NEXT_DIST_DIR` to isolate Next.js build output from Dropbox sync conflicts

## Root cause

The desktop panel used a higher stacking layer than cookie consent, so it masked the part of the consent card that overlapped the panel. At the same time, the full-bleed carousel remained viewport-wide after the main case-study column shrank, allowing slides to continue beneath and beyond the panel.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 27 tests passed
- `PLAYWRIGHT_BASE_URL=http://localhost:3333 pnpm exec playwright test tests/smoke/case-study-panel.spec.ts --reporter=line` — 1 test passed
- manual browser verification at 2048×1228
