### PR TITLE
fix(video): respect Mux playback policy

### DIFF
--- a/apps/web/src/lib/mux-signing.test.ts
+++ b/apps/web/src/lib/mux-signing.test.ts
@@ -67,16 +67,24 @@ describe('attachMuxTokens', () => {
     expect(attachMuxTokens(data).video.asset).not.toHaveProperty('tokens')
   })
 
-  it('attaches tokens to every nested playbackId when configured', () => {
+  it('attaches tokens to every nested signed playbackId when configured', () => {
     process.env.MUX_SIGNING_KEY_ID = config.keyId
     process.env.MUX_SIGNING_PRIVATE_KEY = privateKeyPem
 
     const data = {
       content: [
-        { _type: 'videoBlock', video: { asset: { playbackId: 'one' } } },
+        {
+          _type: 'videoBlock',
+          video: { asset: { playbackId: 'one', playbackPolicy: 'signed' } },
+        },
         {
           _type: 'carouselBlock',
-          items: [{ kind: 'video', video: { asset: { playbackId: 'two' } } }],
+          items: [
+            {
+              kind: 'video',
+              video: { asset: { playbackId: 'two', playbackPolicy: 'signed' } },
+            },
+          ],
         },
         { _type: 'block', children: [{ text: 'hello' }] },
       ],
@@ -94,5 +102,20 @@ describe('attachMuxTokens', () => {
       result.content[1] as { items?: Array<{ video: { asset: { tokens?: unknown } } }> }
     ).items
     expect(items?.[0].video.asset.tokens).toBeTruthy()
+  })
+
+  it('does not attach tokens to public or unspecified playback IDs', () => {
+    process.env.MUX_SIGNING_KEY_ID = config.keyId
+    process.env.MUX_SIGNING_PRIVATE_KEY = privateKeyPem
+
+    const data = {
+      publicVideo: { asset: { playbackId: 'public-id', playbackPolicy: 'public' } },
+      legacyVideo: { asset: { playbackId: 'unspecified-id' } },
+    }
+
+    const result = attachMuxTokens(data)
+
+    expect(result.publicVideo.asset).not.toHaveProperty('tokens')
+    expect(result.legacyVideo.asset).not.toHaveProperty('tokens')
   })
 })

--- a/apps/web/src/lib/mux-signing.ts
+++ b/apps/web/src/lib/mux-signing.ts
@@ -77,9 +77,11 @@ export function getMuxSigningConfigFromEnv(): MuxSigningConfig | null {
 }
 
 /**
- * Deep-walks fetched Sanity data and attaches playback tokens next to every
- * `playbackId` so client components can read `asset.tokens` without each
- * parent threading props. No-op when signing keys are not configured.
+ * Deep-walks fetched Sanity data and attaches playback tokens next to signed
+ * `playbackId` records so client components can read `asset.tokens` without
+ * each parent threading props. Public assets must remain token-free: a token
+ * from another Mux environment makes an otherwise valid public ID fail.
+ * No-op when signing keys are not configured.
  */
 export function attachMuxTokens<T>(value: T): T {
   const config = getMuxSigningConfigFromEnv()
@@ -103,7 +105,11 @@ export function attachMuxTokens<T>(value: T): T {
     if (!node || typeof node !== 'object') return
 
     const record = node as Record<string, unknown>
-    if (typeof record.playbackId === 'string' && record.playbackId) {
+    if (
+      typeof record.playbackId === 'string' &&
+      record.playbackId &&
+      record.playbackPolicy === 'signed'
+    ) {
       record.tokens = tokensFor(record.playbackId)
     }
     for (const child of Object.values(record)) walk(child)

--- a/apps/web/src/sanity/queries.ts
+++ b/apps/web/src/sanity/queries.ts
@@ -5,7 +5,13 @@ import { groq } from 'next-sanity'
 export const IMAGE_ASSET_PROJECTION = groq`{ _id, url, metadata { lqip, dimensions } }`
 export const IMAGE_PROJECTION = groq`{..., asset->${IMAGE_ASSET_PROJECTION}}`
 
-export const MUX_VIDEO_PROJECTION = groq`{ asset->{ playbackId, "aspectRatio": data.aspect_ratio } }`
+export const MUX_VIDEO_PROJECTION = groq`{
+  asset->{
+    playbackId,
+    "playbackPolicy": coalesce(data.playback_ids[0].policy, "public"),
+    "aspectRatio": data.aspect_ratio
+  }
+}`
 export const COVER_PROJECTION = groq`{ type, image${IMAGE_PROJECTION}, video${MUX_VIDEO_PROJECTION} }`
 
 export type SanityImage = {
@@ -40,7 +46,13 @@ export type ImageBlock = {
 export type VideoBlock = {
   _type: 'videoBlock'
   _key?: string
-  video: { asset: { playbackId: string; aspectRatio?: string } }
+  video: {
+    asset: {
+      playbackId: string
+      playbackPolicy?: 'public' | 'signed'
+      aspectRatio?: string
+    }
+  }
   title?: string
   description?: string
 }
@@ -50,7 +62,10 @@ export type CarouselBlock = {
   _key?: string
   items: (
     | { kind: 'image'; image: SanityImage }
-    | { kind: 'video'; video: { asset: { playbackId: string } } }
+    | {
+        kind: 'video'
+        video: { asset: { playbackId: string; playbackPolicy?: 'public' | 'signed' } }
+      }
   )[]
   title?: string
   description?: string
@@ -63,14 +78,32 @@ export type TwoColumnImageBlock = {
   rightKind?: 'image' | 'video'
   leftImage?: SanityImage
   rightImage?: SanityImage
-  leftVideo?: { asset?: { playbackId?: string; aspectRatio?: string } }
-  rightVideo?: { asset?: { playbackId?: string; aspectRatio?: string } }
+  leftVideo?: {
+    asset?: {
+      playbackId?: string
+      playbackPolicy?: 'public' | 'signed'
+      aspectRatio?: string
+    }
+  }
+  rightVideo?: {
+    asset?: {
+      playbackId?: string
+      playbackPolicy?: 'public' | 'signed'
+      aspectRatio?: string
+    }
+  }
 }
 
 export type CoverMedia = {
   type?: 'image' | 'video'
   image?: SanityImage
-  video?: { asset?: { playbackId?: string; aspectRatio?: string } }
+  video?: {
+    asset?: {
+      playbackId?: string
+      playbackPolicy?: 'public' | 'signed'
+      aspectRatio?: string
+    }
+  }
 }
 
 export type CaseStudy = {
@@ -87,7 +120,13 @@ export type CaseStudy = {
   headerMedia?: {
     type: 'image' | 'video'
     image?: SanityImage
-    video?: { asset: { playbackId: string; aspectRatio?: string } }
+    video?: {
+      asset: {
+        playbackId: string
+        playbackPolicy?: 'public' | 'signed'
+        aspectRatio?: string
+      }
+    }
   }
   projectInfo?: {
     client?: string


### PR DESCRIPTION
## What changed

- Project each Mux asset’s playback policy from Sanity.
- Attach JWT playback tokens only to assets explicitly marked `signed`.
- Keep public and legacy/unspecified playback IDs token-free.
- Add regression coverage for signed, public, and unspecified playback IDs.

## Why

Public videos on `/work/tap` were receiving signed JWTs generated for a different Mux environment. Mux rejected the otherwise valid public playback IDs with “The URL or playback-id was invalid.” The header video worked because its reconstructed cover-media path dropped the token, while body videos retained it.

## Impact

All public TAP videos now load directly with their public playback IDs. Signed recruiter-only videos continue to receive tokens.

## Validation

- `pnpm --filter web exec vitest run --project unit src/lib/mux-signing.test.ts` — 6 tests passed
- `pnpm --filter web typecheck` — passed
- Targeted ESLint for the three changed files — passed
- Browser verification on `/work/tap` — all five Mux players reached ready state 4, autoplayed, and reported no media errors